### PR TITLE
Fix for segment intersection testing in cartesian geometry

### DIFF
--- a/lib/rgeo/cartesian/calculations.rb
+++ b/lib/rgeo/cartesian/calculations.rb
@@ -113,7 +113,7 @@ module RGeo
         dx2_ = seg_.dx
         dy2_ = seg_.dy
         denom_ = @dx*dy2_ - @dy*dx2_
-        return side(s2_) == 0 if denom_ == 0
+        return contains_point?(s2_) if denom_ == 0
         t_ = (dy2_ * (sx2_ - @sx) + dx2_ * (@sy - sy2_)) / denom_
         return false if t_ < 0.0 || t_ > 1.0
         t2_ = (@dy * (sx2_ - @sx) + @dx * (@sy - sy2_)) / denom_


### PR DESCRIPTION
Hi!

I was looking at the segment intersection test in cartesian calculations. It doesn't seem to handle the case when two segments are parallel.

When they're parallel we should check whether the start of the first segment belongs to the second segment, not only the line on which it lies. 

Am I missing something?
