### PR TITLE
Allow extra co-ordinate values to be stored

### DIFF
--- a/lib/rgeo/impl_helper/basic_point_methods.rb
+++ b/lib/rgeo/impl_helper/basic_point_methods.rb
@@ -41,6 +41,7 @@ module RGeo
     
     module BasicPointMethods  # :nodoc:
       
+      attr_reader :extra
       
       def initialize(factory_, x_, y_, *extra_)
         _set_factory(factory_)
@@ -48,9 +49,7 @@ module RGeo
         @y = y_.to_f
         @z = factory_.property(:has_z_coordinate) ? extra_.shift.to_f : nil
         @m = factory_.property(:has_m_coordinate) ? extra_.shift.to_f : nil
-        if extra_.size > 0
-          raise ::ArgumentError, "Too many arguments for point initializer"
-        end
+        @extra = extra_
         _validate_geometry
       end
       

--- a/test/common/point_tests.rb
+++ b/test/common/point_tests.rb
@@ -318,6 +318,16 @@ module RGeo
         end
         
         
+        def test_creation_with_extra_values
+          point_ = @zmfactory.point(11, 12, 13, 14, 15, 16, 17)
+          assert_equal(11, point_.x)
+          assert_equal(12, point_.y)
+          assert_equal(13, point_.z)
+          assert_equal(14, point_.m)
+          assert_equal([15, 16, 17], point_.extra)
+        end
+        
+        
         def test_wkt_creation_3d
           point2_ = @zfactory.parse_wkt('POINT(11 12 13)')
           assert_equal(11, point2_.x)


### PR DESCRIPTION
Allow extra co-ordinate values to be stored, to support the extra values allowed in the GeoJSON spec.

This patch is in support to Issue #2 for rgeo-geojson.
