### PR TITLE
Parse 'NAN' values in WKT formats

### DIFF
--- a/lib/rgeo/cartesian/factory.rb
+++ b/lib/rgeo/cartesian/factory.rb
@@ -256,6 +256,7 @@ module RGeo
       # See ::RGeo::Feature::Factory#parse_wkt
 
       def parse_wkt(str_)
+        str_.gsub!('NAN','0.0')
         @wkt_parser.parse(str_)
       end
 

--- a/lib/rgeo/geographic/factory.rb
+++ b/lib/rgeo/geographic/factory.rb
@@ -360,6 +360,7 @@ module RGeo
       # See ::RGeo::Feature::Factory#parse_wkt
 
       def parse_wkt(str_)
+        str_.gsub!('NAN','0.0')
         @wkt_parser.parse(str_)
       end
 

--- a/lib/rgeo/geos/capi_factory.rb
+++ b/lib/rgeo/geos/capi_factory.rb
@@ -328,6 +328,7 @@ module RGeo
       # See ::RGeo::Feature::Factory#parse_wkt
 
       def parse_wkt(str_)
+        str_.gsub!('NAN','0.0')
         if (wkt_parser_ = self._wkt_parser)
           wkt_parser_.parse(str_)
         else

--- a/lib/rgeo/geos/ffi_factory.rb
+++ b/lib/rgeo/geos/ffi_factory.rb
@@ -325,6 +325,7 @@ module RGeo
       # See ::RGeo::Feature::Factory#parse_wkt
 
       def parse_wkt(str_)
+	      str_.gsub!('NAN','0.0')
         if @wkt_reader
           _wrap_fg_geom(@wkt_reader.read(str_), nil)
         else

--- a/lib/rgeo/geos/zm_factory.rb
+++ b/lib/rgeo/geos/zm_factory.rb
@@ -309,6 +309,7 @@ module RGeo
       # See ::RGeo::Feature::Factory#parse_wkt
 
       def parse_wkt(str_)
+        str_.gsub!('NAN','0.0')
         @wkt_parser.parse(str_)
       end
 


### PR DESCRIPTION
This commit adds a hackish gsub! to string arguments passed to
parse_wkt methods in the factories. Some geometric objects can
develop 'NAN' values when adding a dimension and WKT parsing of
these value fails.
