### PR TITLE
Use geos-config to compile/link correctly against GEOS.

### DIFF
--- a/ext/geos_c_impl/extconf.rb
+++ b/ext/geos_c_impl/extconf.rb
@@ -44,7 +44,7 @@ else
   if geosconfig = (with_config('geos-config') || find_executable('geos-config'))
     puts "Using GEOS compile configuration from %s" [ geosconfig ]
     $INCFLAGS << " " << `#{geosconfig} --cflags`.strip
-    geos_libs = `#{geosconfig} --libs --clibs`.gsub("\n", " ")
+    geos_libs = `#{geosconfig} --clibs`.gsub("\n", " ")
     geos_libs.split(/\s+/).each do |flag|
       $libs << ' ' + flag unless $libs.include?(flag)
     end

--- a/ext/geos_c_impl/extconf.rb
+++ b/ext/geos_c_impl/extconf.rb
@@ -41,6 +41,23 @@ if ::RUBY_DESCRIPTION =~ /^jruby\s/
 else
 
   require 'mkmf'
+  require 'rbconfig'
+
+  if find_executable('geos-config')
+    $CFLAGS << " #{`geos-config --cflags`.strip}"
+    $LIBS << " #{`geos-config --libs`.strip}"
+  else
+  end
+
+  if CONFIG['CC'] =~ /gcc/
+    $CFLAGS << ' -Wall -Wextra'
+  end
+
+  create_makefile('rgeo/geos/geos_c_impl')
+end
+
+if false
+  require 'mkmf'
 
   header_dirs_ =
     [

--- a/ext/geos_c_impl/extconf.rb
+++ b/ext/geos_c_impl/extconf.rb
@@ -39,71 +39,32 @@ if ::RUBY_DESCRIPTION =~ /^jruby\s/
   ::File.open('Makefile', 'w'){ |f_| f_.write(".PHONY: install\ninstall:\n") }
 
 else
-
-  require 'mkmf'
-  require 'rbconfig'
-
-  if find_executable('geos-config')
-    $CFLAGS << " #{`geos-config --cflags`.strip}"
-    $LIBS << " #{`geos-config --libs`.strip}"
-  else
-  end
-
-  if CONFIG['CC'] =~ /gcc/
-    $CFLAGS << ' -Wall -Wextra'
-  end
-
-  create_makefile('rgeo/geos/geos_c_impl')
-end
-
-if false
   require 'mkmf'
 
-  header_dirs_ =
-    [
-     '/usr/local/include',
-     '/usr/local/geos/include',
-     '/opt/local/include',
-     '/opt/geos/include',
-     '/opt/include',
-     '/Library/Frameworks/GEOS.framework/unix/include',
-     ::RbConfig::CONFIG['includedir'],
-     '/usr/include',
-    ]
-  lib_dirs_ =
-    [
-     '/usr/local/lib64',
-     '/usr/local/lib',
-     '/usr/local/geos/lib',
-     '/opt/local/lib',
-     '/opt/geos/lib',
-     '/opt/lib',
-     '/Library/Frameworks/GEOS.framework/unix/lib',
-     ::RbConfig::CONFIG['libdir'],
-     '/usr/lib64',
-     '/usr/lib',
-    ]
-  header_dirs_.delete_if{ |path_| !::File.directory?(path_) }
-  lib_dirs_.delete_if{ |path_| !::File.directory?(path_) }
+  if geosconfig = (with_config('geos-config') || find_executable('geos-config'))
+    puts "Using GEOS compile configuration from %s" [ geosconfig ]
+    $INCFLAGS << " " << `#{geosconfig} --cflags`.strip
+    geos_libs = `#{geosconfig} --libs --clibs`.gsub("\n", " ")
+    geos_libs.split(/\s+/).each do |flag|
+      $libs << ' ' + flag unless $libs.include?(flag)
+    end
+  end
 
   found_geos_ = false
-  header_dirs_, lib_dirs_ = dir_config('geos', header_dirs_, lib_dirs_)
   if have_header('geos_c.h')
-    $libs << ' -lgeos -lgeos_c'
     if have_func('GEOSSetSRID_r', 'geos_c.h')
       found_geos_ = true
-    else
-      $libs.gsub!(' -lgeos -lgeos_c', '')
     end
     have_func('GEOSPreparedContains_r', 'geos_c.h')
     have_func('GEOSPreparedDisjoint_r', 'geos_c.h')
-    have_func('GEOSWKTWriter_setOutputDimension_r', 'geos_c.h')
     have_func('rb_memhash', 'ruby.h')
   end
+
   unless found_geos_
-    puts "**** WARNING: Unable to find GEOS headers or GEOS version is too old."
+    puts "**** WARNING: Unable to find GEOS headers or libraries."
+    puts "**** Ensure that 'geos-config' is in your PATH or provide that full path via --with-geos-config"
     puts "**** Compiling without GEOS support."
   end
-  create_makefile('rgeo/geos/geos_c_impl')
 
+  create_makefile('rgeo/geos/geos_c_impl')
 end


### PR DESCRIPTION
This request changes extconf.rb to rely on geos-config to discover correct GEOS header/library paths *and* names, rather than just a list of paths.

This should fix:
https://github.com/rgeo/rgeo/issues/60
https://github.com/rgeo/rgeo/issues/73
and should re-instate the CAPI tests on Travis which are currently being skipped.