### PR TITLE
add #simplify for Polygon and MultiPoligon when using CAPI

### DIFF
--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -479,7 +479,6 @@ static VALUE method_multi_polygon_centroid(VALUE self)
   return result;
 }
 
-
 static VALUE method_multi_polygon_point_on_surface(VALUE self)
 {
   VALUE result;
@@ -495,6 +494,24 @@ static VALUE method_multi_polygon_point_on_surface(VALUE self)
   return result;
 }
 
+static VALUE method_multi_polygon_simplify(VALUE self, VALUE tolerance)
+{
+  VALUE result;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  GEOSContextHandle_t self_context;
+  double ctolerance = NUM2DBL(tolerance);
+
+  result = Qnil;
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+  if (self_geom) {
+      self_context = self_data->geos_context;
+      GEOSGeometry *geom = GEOSSimplify_r(self_context, self_geom, ctolerance);
+      result = rgeo_wrap_geos_geometry(self_data->factory, geom, Qnil);
+  }
+  return result;
+}
 
 static VALUE cmethod_geometry_collection_create(VALUE module, VALUE factory, VALUE array)
 {
@@ -566,6 +583,7 @@ void rgeo_init_geos_geometry_collection(RGeo_Globals* globals)
   rb_define_method(geos_multi_polygon_methods, "area", method_multi_polygon_area, 0);
   rb_define_method(geos_multi_polygon_methods, "centroid", method_multi_polygon_centroid, 0);
   rb_define_method(geos_multi_polygon_methods, "point_on_surface", method_multi_polygon_point_on_surface, 0);
+  rb_define_method(geos_multi_polygon_methods, "simplify", method_multi_polygon_simplify, 1);
   rb_define_method(geos_multi_polygon_methods, "hash", method_multi_polygon_hash, 0);
 }
 

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -285,6 +285,25 @@ static VALUE cmethod_create(VALUE module, VALUE factory, VALUE exterior, VALUE i
   return Qnil;
 }
 
+static VALUE method_polygon_simplify(VALUE self, VALUE tolerance)
+{
+  VALUE result;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  GEOSContextHandle_t self_context;
+  double ctolerance = NUM2DBL(tolerance);
+
+  result = Qnil;
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+  if (self_geom) {
+      self_context = self_data->geos_context;
+      GEOSGeometry *geom = GEOSSimplify_r(self_context, self_geom, ctolerance);
+      VALUE klass = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->geos_polygon;
+      result = rgeo_wrap_geos_geometry(self_data->factory, geom, klass);
+  }
+  return result;
+}
 
 void rgeo_init_geos_polygon(RGeo_Globals* globals)
 {
@@ -306,6 +325,7 @@ void rgeo_init_geos_polygon(RGeo_Globals* globals)
   rb_define_method(geos_polygon_methods, "num_interior_rings", method_polygon_num_interior_rings, 0);
   rb_define_method(geos_polygon_methods, "interior_ring_n", method_polygon_interior_ring_n, 1);
   rb_define_method(geos_polygon_methods, "interior_rings", method_polygon_interior_rings, 0);
+  rb_define_method(geos_polygon_methods, "simplify", method_polygon_simplify, 1);
 }
 
 

--- a/test/geos_capi/tc_multi_polygon.rb
+++ b/test/geos_capi/tc_multi_polygon.rb
@@ -62,6 +62,18 @@ module RGeo
           assert_equal(@factory.collection([]), @factory.multi_polygon([]).centroid)
         end
 
+        def test_simplify
+          point1_ = @factory.point(0, 0)
+          point2_ = @factory.point(0, 2)
+          point3_ = @factory.point(2, 2)
+          point4_ = @factory.point(2, 0)
+          point5_ = @factory.point(2.00001, 0)
+          poly1_ = @factory.polygon(@factory.linear_ring([point1_, point2_, point3_, point4_, point5_]))
+          poly2_ = @factory.polygon(@factory.linear_ring([point1_, point2_, point3_, point5_]))
+          mp1_ = @lenient_factory.multi_polygon([poly1_, poly1_])
+          mp2_ = @lenient_factory.multi_polygon([poly2_, poly2_])
+          assert_equal(mp2_, mp1_.simplify(0.1))
+        end
 
         def _test_geos_bug_582
           f_ = ::RGeo::Geos.factory(:buffer_resolution => 2)
@@ -70,7 +82,6 @@ module RGeo
           mp_ = f_.multi_polygon([p2_, p1_])
           mp_.centroid.as_text
         end
-
 
       end
 

--- a/test/geos_capi/tc_polygon.rb
+++ b/test/geos_capi/tc_polygon.rb
@@ -78,6 +78,18 @@ module RGeo
           assert_equal(poly1_, poly3_)
         end
 
+        def test_simplify
+          point1_ = @factory.point(0, 0)
+          point2_ = @factory.point(0, 2)
+          point3_ = @factory.point(2, 2)
+          point4_ = @factory.point(2, 0)
+          point5_ = @factory.point(2.00001, 0)
+          poly1_ = @factory.polygon(@factory.linear_ring([point1_, point2_, point3_, point4_, point5_]))
+          poly2_ = @factory.polygon(@factory.linear_ring([point1_, point2_, point3_, point5_]))
+          assert_not_equal(poly1_, poly1_.simplify(1))
+          assert_equal(poly2_, poly1_.simplify(1))
+        end
+
 
       end
 


### PR DESCRIPTION
Hello, these add support for for using simplify without passing from FFI.

I added this because Heroku is bugged and doesn't support FFI on the Cedar stack, and they have no clue how to fix it (see: https://github.com/ffi/ffi/issues/344).

I'm not sure why in the MultiPolygon test I needed to use `@lenient_factory` (normal factory would return `nil`), maybe you can help me there so that I can possibly change it.

Please let me know if I have to change something!