### PR TITLE
Fix Marshal and Psych support for native geos factories

### DIFF
--- a/lib/rgeo/geos/capi_factory.rb
+++ b/lib/rgeo/geos/capi_factory.rb
@@ -182,10 +182,10 @@ module RGeo
           'hasm' => (_flags & 0x4 != 0),
           'srid' => _srid,
           'bufr' => _buffer_resolution,
-          'wktg' => _wkt_generator._properties,
-          'wkbg' => _wkb_generator._properties,
-          'wktp' => _wkt_parser._properties,
-          'wkbp' => _wkb_parser._properties,
+          'wktg' => _wkt_generator ? _wkt_generator._properties : {},
+          'wkbg' => _wkb_generator ? _wkb_generator._properties : {},
+          'wktp' => _wkt_parser ? _wkt_parser._properties : {},
+          'wkbp' => _wkb_parser ? _wkb_parser._properties : {},
           'lmpa' => (_flags & 0x1 != 0),
           'apre' => ((_flags & 0x8) >> 3),
         }
@@ -235,10 +235,10 @@ module RGeo
         coder_['srid'] = _srid
         coder_['buffer_resolution'] = _buffer_resolution
         coder_['lenient_multi_polygon_assertions'] = (_flags & 0x1 != 0)
-        coder_['wkt_generator'] = _wkt_generator._properties
-        coder_['wkb_generator'] = _wkb_generator._properties
-        coder_['wkt_parser'] = _wkt_parser._properties
-        coder_['wkb_parser'] = _wkb_parser._properties
+        coder_['wkt_generator'] = _wkt_generator ? _wkt_generator._properties : {}
+        coder_['wkb_generator'] = _wkb_generator ? _wkb_generator._properties : {}
+        coder_['wkt_parser'] = _wkt_parser ? _wkt_parser._properties : {}
+        coder_['wkb_parser'] = _wkb_parser ? _wkb_parser._properties : {}
         coder_['auto_prepare'] = ((_flags & 0x8) == 0 ? 'disabled' : 'simple')
         if (proj4_ = self._proj4)
           str_ = proj4_.original_str || proj4_.canonical_str

--- a/test/geos_capi/tc_misc.rb
+++ b/test/geos_capi/tc_misc.rb
@@ -50,6 +50,42 @@ module RGeo
         end
 
 
+        def test_marshal_dump_with_geos
+          @factory = ::RGeo::Geos.factory(
+            :srid => 4326,
+            :wkt_generator => :geos,
+            :wkb_generator => :geos,
+            :wkt_parser => :geos,
+            :wkb_parser => :geos
+          )
+
+          dump = nil
+          assert_nothing_raised { dump = @factory.marshal_dump }
+          assert_equal({}, dump['wktg'])
+          assert_equal({}, dump['wkbg'])
+          assert_equal({}, dump['wktp'])
+          assert_equal({}, dump['wkbp'])
+        end
+
+
+        def test_encode_with_geos
+          @factory = ::RGeo::Geos.factory(
+            :srid => 4326,
+            :wkt_generator => :geos,
+            :wkb_generator => :geos,
+            :wkt_parser => :geos,
+            :wkb_parser => :geos
+          )
+          coder = Psych::Coder.new('test')
+
+          assert_nothing_raised { @factory.encode_with(coder) }
+          assert_equal({}, coder['wkt_generator'])
+          assert_equal({}, coder['wkb_generator'])
+          assert_equal({}, coder['wkt_parser'])
+          assert_equal({}, coder['wkb_parser'])
+        end
+
+
         def test_uninitialized
           geom_ = ::RGeo::Geos::CAPIGeometryImpl.new
           assert_equal(false, geom_.initialized?)


### PR DESCRIPTION
When a factory uses native geos for wkb/wkt generation/parsing Psych
and marshal functions were unable to serialize the generators/parsers.
It seems like the methods assumed that the generators/parsers were WKRep
objects. When generators and parsers are using geos they seem to return nil. This prevents encode_with and marshal_dump from calling _properties on nil.