### PR TITLE
Incorrect calculation of proj_window.random_point

### DIFF
--- a/lib/rgeo/geographic/projected_window.rb
+++ b/lib/rgeo/geographic/projected_window.rb
@@ -240,18 +240,14 @@ module RGeo
       end
 
 
-      # Returns a random point the rectangle in _unprojected_
+      # Returns a random point inside the rectangle in _unprojected_
       # (lat/lng) space, as a Feature::Point object.
 
       def random_point
-        y_ = @y_min + (@y_max - @y_min) * rand
-        if @x_min > @x_max
-          x_ = @x_min + x_span * rand
-          limits_ = @factory.projection_limits_window
-          x_ -= limits_.x_span if x_ >= limits_.x_max
-        else
-          x_ = (@x_min + @x_max) * rand
-        end
+        y_ = @y_min + y_span * rand
+        x_ = @x_min + x_span * rand
+        limits_ = @factory.projection_limits_window
+        x_ -= limits_.x_span if x_ >= limits_.x_max
         @factory.unproject(@factory.projection_factory.point(x_, y_))
       end
 

--- a/test/simple_mercator/tc_window.rb
+++ b/test/simple_mercator/tc_window.rb
@@ -87,6 +87,14 @@ module RGeo
         end
 
 
+        def test_random_point
+          window1_ = Geographic::ProjectedWindow.for_corners(@factory.point(-170, 30), @factory.point(-160, 40))
+          20.times { assert(window1_.contains_point?(window1_.random_point)) }
+          window2_ = Geographic::ProjectedWindow.for_corners(@factory.point(170, 30), @factory.point(-170, 40))
+          20.times { assert(window2_.contains_point?(window2_.random_point)) }
+        end
+
+
         def test_crosses_seam
           window1_ = Geographic::ProjectedWindow.for_corners(@factory.point(-170, 30), @factory.point(170, 40))
           assert(!window1_.crosses_seam?)


### PR DESCRIPTION
Fixes the incorrect calculation of RGeo::Geographic::ProjectedWindow#random_point.
Specifically the x coordinate would usually be outside the bounds of the window.