### PR TITLE
Use canonical_point when validating line string

### DIFF
--- a/lib/rgeo/geographic/projected_feature_methods.rb
+++ b/lib/rgeo/geographic/projected_feature_methods.rb
@@ -215,28 +215,7 @@ module RGeo
 
 
       def _validate_geometry
-        size_ = @points.size
-        if size_ > 1
-          last_ = @points[0]
-          (1...size_).each do |i_|
-            p_ = @points[i_]
-            last_x_ = last_.x
-            p_x_ = p_.x
-            changed_ = true
-            if p_x_ < last_x_ - 180.0
-              p_x_ += 360.0 while p_x_ < last_x_ - 180.0
-            elsif p_x_ > last_x_ + 180.0
-              p_x_ -= 360.0 while p_x_ > last_x_ + 180.0
-            else
-              changed_ = false
-            end
-            if changed_
-              p_ = factory.point(p_x_, p_.y)
-              @points[i_] = p_
-            end
-            last_ = p_
-          end
-        end
+        @points = @points.map(&:canonical_point)
         super
       end
 


### PR DESCRIPTION
I have the following code:
```ruby
p0min = RGeo::Geographic.simple_mercator_factory.point(-169.478,-56)
p0max = RGeo::Geographic.simple_mercator_factory.point(167.95,64.8333)
bbox = RGeo::Cartesian::BoundingBox.create_from_points(p0min, p0max)
bbox.to_geometry
```

I would expect this to output
```ruby
#<RGeo::Geographic::ProjectedPolygonImpl:0x3fcd525b1d00 "POLYGON ((-169.478 -56.0, 167.95 -56.0, 167.95 64.8333, -169.478 64.8333, -169.478 -56.0))"> 
```

instead it does output
```ruby
#<RGeo::Geographic::ProjectedPolygonImpl:0x3fcd525b1d00 "POLYGON ((-169.478 -56.0, -192.05 -56.0, -192.05 64.8333, -169.478 64.8333, -169.478 -56.0))"> 
```

that is the x coordinate of p0max is shifted -360 degrees.
This happens because of https://github.com/rgeo/rgeo/blob/master/lib/rgeo/geographic/projected_feature_methods.rb#L229
I'm not sure why that code does that, but I would think all that's needed is to just convert x coordinates outside of [-180,180] to fall inside this range.