### PR TITLE
fix SharpGis links in spatial programming Markdown

### DIFF
--- a/Spatial_Programming_With_RGeo.md
+++ b/Spatial_Programming_With_RGeo.md
@@ -577,9 +577,9 @@ straight line between those two points. But what is meant by "straight"? Does
 the shape follow the 50 degrees north latitude line, passing through
 Newfoundland? Or does it follow the actual shortest path on the globe, which
 passes much further north, close to Reykjavik, Iceland? (For a detailed
-explanation, see Morten Nielsen's post ["Straight Lines on a
-Sphere"](http://www.sharpgis.net/post/2008/01/12/Straight-lines-on-a-sphere.as
-px), which also includes some helpful diagrams.) If you were to call the SFS
+explanation, see Morten Nielsen's post ["Straight Lines on a Sphere"]
+(http://www.sharpgis.net/post/2008/01/12/Straight-lines-on-a-sphere.aspx),
+which also includes some helpful diagrams.) If you were to call the SFS
 "distance" function to measure the distance between this LineString and a
 Point located at Reykjavik, what would you get?
 
@@ -619,9 +619,8 @@ straight Line in geographic coordinates) into a Mercator-projected Google map,
 the line will be curved. Therefore, the coordinate system is an integral part
 of the geometric object. If you get your coordinate systems mixed up, you may
 get incorrect results when you run a database query or a geometric operation.
-Morten Nielsen gives an example in [this
-post](http://www.sharpgis.net/post/2009/02/06/Why-EPSG4326-is-usually-the-wron
-g-e2809cprojectione2809d.aspx).
+Morten Nielsen gives an example in [this post]
+(http://www.sharpgis.net/post/2009/02/06/Why-EPSG4326-is-usually-the-wrong-e2809cprojectione2809d.aspx).
 
     flat_factory = RGeo::Geos.factory
     curved_factory = RGeo::Geographic.spherical_factory
@@ -750,9 +749,8 @@ systems with a projection. The API inputs take latitude and longitude in the
 WGS84 coordinate system. However, the maps themselves are Mercator projections
 (with a minor modification to make computations easier), and so the map
 implementations transform the coordinates internally. Again, Morten Nielsen
-provides a more [detailed
-description](http://www.sharpgis.net/post/2007/07/27/The-Microsoft-Live-Maps-a
-nd-Google-Maps-projection.aspx).
+provides a more [detailed description]
+(http://www.sharpgis.net/post/2007/07/27/The-Microsoft-Live-Maps-and-Google-Maps-projection.aspx).
 
 ### 4.4. Using Proj4
 


### PR DESCRIPTION
The links to 3 SharpGIS blog posts were broken in [An Introduction to Spatial Programming With RGeo](https://github.com/rgeo/rgeo/blob/master/Spatial_Programming_With_RGeo.md) because line breaks in their Markdown were rendered as `%0A`, which didn't belong in those URLs.