### PR TITLE
Fast coordinates

### DIFF
--- a/ext/geos_c_impl/coordinates.c
+++ b/ext/geos_c_impl/coordinates.c
@@ -1,0 +1,57 @@
+#include <ruby.h>
+#include <geos_c.h>
+
+
+VALUE extract_points_from_coordinate_sequence(GEOSContextHandle_t context, const GEOSCoordSequence* coord_sequence)
+{
+  VALUE result = Qnil;
+  VALUE point;
+  unsigned int count;
+  unsigned int i;
+  double val;
+
+  if(GEOSCoordSeq_getSize_r(context, coord_sequence, &count)) {
+    result = rb_ary_new2(count);
+    for(i = 0; i < count; ++i) {
+      point = rb_ary_new2(2);
+      GEOSCoordSeq_getX_r(context, coord_sequence, i, &val);
+      rb_ary_push(point, rb_float_new(val));
+      GEOSCoordSeq_getY_r(context, coord_sequence, i, &val);
+      rb_ary_push(point, rb_float_new(val));
+      rb_ary_push(result, point);
+    }
+  }
+
+  return result;
+}
+
+VALUE extract_points_from_polygon(GEOSContextHandle_t context, const GEOSGeometry* polygon)
+{
+  VALUE result = Qnil;
+
+  const GEOSGeometry* ring;
+  const GEOSCoordSequence* coord_sequence;
+  unsigned int interior_ring_count;
+  unsigned int i;
+
+  if (polygon) {
+    ring = GEOSGetExteriorRing_r(context, polygon);
+    coord_sequence = GEOSGeom_getCoordSeq_r(context, ring);
+
+    if(coord_sequence) {
+      interior_ring_count = GEOSGetNumInteriorRings_r(context, polygon);
+      result = rb_ary_new2(interior_ring_count + 1); // exterior + inner rings
+
+      rb_ary_push(result, extract_points_from_coordinate_sequence(context, coord_sequence));
+
+      for(i = 0; i < interior_ring_count; ++i) {
+        ring = GEOSGetInteriorRingN_r(context, polygon, i);
+        coord_sequence = GEOSGeom_getCoordSeq_r(context, ring);
+        if(coord_sequence) {
+          rb_ary_push(result, extract_points_from_coordinate_sequence(context, coord_sequence));
+        }
+      }
+    }
+  }
+  return result;
+}

--- a/ext/geos_c_impl/coordinates.c
+++ b/ext/geos_c_impl/coordinates.c
@@ -2,7 +2,7 @@
 #include <geos_c.h>
 
 
-VALUE extract_points_from_coordinate_sequence(GEOSContextHandle_t context, const GEOSCoordSequence* coord_sequence)
+VALUE extract_points_from_coordinate_sequence(GEOSContextHandle_t context, const GEOSCoordSequence* coord_sequence, int zCoordinate)
 {
   VALUE result = Qnil;
   VALUE point;
@@ -13,11 +13,19 @@ VALUE extract_points_from_coordinate_sequence(GEOSContextHandle_t context, const
   if(GEOSCoordSeq_getSize_r(context, coord_sequence, &count)) {
     result = rb_ary_new2(count);
     for(i = 0; i < count; ++i) {
-      point = rb_ary_new2(2);
+      if(zCoordinate) {
+        point = rb_ary_new2(3);
+      } else {
+        point = rb_ary_new2(2);
+      }
       GEOSCoordSeq_getX_r(context, coord_sequence, i, &val);
       rb_ary_push(point, rb_float_new(val));
       GEOSCoordSeq_getY_r(context, coord_sequence, i, &val);
       rb_ary_push(point, rb_float_new(val));
+      if(zCoordinate) {
+        GEOSCoordSeq_getZ_r(context, coord_sequence, i, &val);
+        rb_ary_push(point, rb_float_new(val));
+      }
       rb_ary_push(result, point);
     }
   }
@@ -25,7 +33,7 @@ VALUE extract_points_from_coordinate_sequence(GEOSContextHandle_t context, const
   return result;
 }
 
-VALUE extract_points_from_polygon(GEOSContextHandle_t context, const GEOSGeometry* polygon)
+VALUE extract_points_from_polygon(GEOSContextHandle_t context, const GEOSGeometry* polygon, int zCoordinate)
 {
   VALUE result = Qnil;
 
@@ -42,13 +50,13 @@ VALUE extract_points_from_polygon(GEOSContextHandle_t context, const GEOSGeometr
       interior_ring_count = GEOSGetNumInteriorRings_r(context, polygon);
       result = rb_ary_new2(interior_ring_count + 1); // exterior + inner rings
 
-      rb_ary_push(result, extract_points_from_coordinate_sequence(context, coord_sequence));
+      rb_ary_push(result, extract_points_from_coordinate_sequence(context, coord_sequence, zCoordinate));
 
       for(i = 0; i < interior_ring_count; ++i) {
         ring = GEOSGetInteriorRingN_r(context, polygon, i);
         coord_sequence = GEOSGeom_getCoordSeq_r(context, ring);
         if(coord_sequence) {
-          rb_ary_push(result, extract_points_from_coordinate_sequence(context, coord_sequence));
+          rb_ary_push(result, extract_points_from_coordinate_sequence(context, coord_sequence, zCoordinate));
         }
       }
     }

--- a/ext/geos_c_impl/coordinates.h
+++ b/ext/geos_c_impl/coordinates.h
@@ -1,0 +1,2 @@
+VALUE extract_points_from_coordinate_sequence(GEOSContextHandle_t context, const GEOSCoordSequence* coord_sequence);
+VALUE extract_points_from_polygon(GEOSContextHandle_t context, const GEOSGeometry* polygon);

--- a/ext/geos_c_impl/coordinates.h
+++ b/ext/geos_c_impl/coordinates.h
@@ -1,2 +1,2 @@
-VALUE extract_points_from_coordinate_sequence(GEOSContextHandle_t context, const GEOSCoordSequence* coord_sequence);
-VALUE extract_points_from_polygon(GEOSContextHandle_t context, const GEOSGeometry* polygon);
+VALUE extract_points_from_coordinate_sequence(GEOSContextHandle_t context, const GEOSCoordSequence* coord_sequence, int zCoordinate);
+VALUE extract_points_from_polygon(GEOSContextHandle_t context, const GEOSGeometry* polygon, int zCoordinate);

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -313,18 +313,20 @@ static VALUE method_multi_point_coordinates(VALUE self)
   const GEOSGeometry* point;
   unsigned int count;
   unsigned int i;
+  int zCoordinate;
 
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
 
   if(self_geom) {
+    zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
     context = self_data->geos_context;
     count = GEOSGetNumGeometries_r(context, self_geom);
     result = rb_ary_new2(count);
     for(i = 0; i < count; ++i) {
       point = GEOSGetGeometryN_r(context, self_geom, i);
       coord_sequence = GEOSGeom_getCoordSeq_r(context, point);
-      rb_ary_push(result, rb_ary_pop(extract_points_from_coordinate_sequence(context, coord_sequence)));
+      rb_ary_push(result, rb_ary_pop(extract_points_from_coordinate_sequence(context, coord_sequence, zCoordinate)));
     }
   }
 
@@ -373,18 +375,20 @@ static VALUE method_multi_line_string_coordinates(VALUE self)
   const GEOSGeometry* line_string;
   unsigned int count;
   unsigned int i;
+  int zCoordinate;
 
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   
   if(self_geom) {
+    zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
     context = self_data->geos_context;
     count = GEOSGetNumGeometries_r(context, self_geom);
     result = rb_ary_new2(count);
     for(i = 0; i < count; ++i) {
       line_string = GEOSGetGeometryN_r(context, self_geom, i);
       coord_sequence = GEOSGeom_getCoordSeq_r(context, line_string);
-      rb_ary_push(result, extract_points_from_coordinate_sequence(context, coord_sequence));
+      rb_ary_push(result, extract_points_from_coordinate_sequence(context, coord_sequence, zCoordinate));
     }
   }
 
@@ -483,17 +487,19 @@ static VALUE method_multi_polygon_coordinates(VALUE self)
   const GEOSGeometry* poly;
   unsigned int count;
   unsigned int i;
+  int zCoordinate;
 
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   
   if(self_geom) {
+    zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
     context = self_data->geos_context;
     count = GEOSGetNumGeometries_r(context, self_geom);
     result = rb_ary_new2(count);
     for(i = 0; i < count; ++i) {
       poly = GEOSGetGeometryN_r(context, self_geom, i);
-      rb_ary_push(result, extract_points_from_polygon(context, poly));
+      rb_ary_push(result, extract_points_from_polygon(context, poly, zCoordinate));
     }
   }
 

--- a/ext/geos_c_impl/line_string.c
+++ b/ext/geos_c_impl/line_string.c
@@ -112,19 +112,20 @@ static VALUE method_line_string_coordinates(VALUE self)
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
   const GEOSCoordSequence* coord_sequence;
-  
+  int zCoordinate;
+
   GEOSContextHandle_t context;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
 
-
   if (self_geom) {
+    zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
     context = self_data->geos_context;
     coord_sequence = GEOSGeom_getCoordSeq_r(context, self_geom);
     if(coord_sequence) {
-      result = extract_points_from_coordinate_sequence(context, coord_sequence);
+      result = extract_points_from_coordinate_sequence(context, coord_sequence, zCoordinate);
     }
   }
   return result;

--- a/ext/geos_c_impl/line_string.c
+++ b/ext/geos_c_impl/line_string.c
@@ -16,6 +16,8 @@
 #include "point.h"
 #include "line_string.h"
 
+#include "coordinates.h"
+
 RGEO_BEGIN_C
 
 
@@ -94,6 +96,40 @@ static VALUE method_line_string_num_points(VALUE self)
   }
   return result;
 }
+
+
+static void d(VALUE v) {
+    ID sym_puts = rb_intern("puts");
+    ID sym_inspect = rb_intern("inspect");
+    rb_funcall(rb_mKernel, sym_puts, 1,
+        rb_funcall(v, sym_inspect, 0));
+}
+
+static VALUE method_line_string_coordinates(VALUE self)
+{
+  VALUE result;
+  VALUE point_tuple;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  const GEOSCoordSequence* coord_sequence;
+  
+  GEOSContextHandle_t context;
+
+  result = Qnil;
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+
+
+  if (self_geom) {
+    context = self_data->geos_context;
+    coord_sequence = GEOSGeom_getCoordSeq_r(context, self_geom);
+    if(coord_sequence) {
+      result = extract_points_from_coordinate_sequence(context, coord_sequence);
+    }
+  }
+  return result;
+}
+
 
 
 static VALUE get_point_from_coordseq(VALUE self, const GEOSCoordSequence* coord_seq, unsigned int i, char has_z)
@@ -589,6 +625,7 @@ void rgeo_init_geos_line_string(RGeo_Globals* globals)
   rb_define_method(geos_line_string_methods, "end_point", method_line_string_end_point, 0);
   rb_define_method(geos_line_string_methods, "is_closed?", method_line_string_is_closed, 0);
   rb_define_method(geos_line_string_methods, "is_ring?", method_line_string_is_ring, 0);
+  rb_define_method(geos_line_string_methods, "coordinates", method_line_string_coordinates, 0);
 
   // CAPILinearRingMethods module
   geos_linear_ring_methods = rb_define_module_under(globals->geos_module, "CAPILinearRingMethods");

--- a/ext/geos_c_impl/point.c
+++ b/ext/geos_c_impl/point.c
@@ -13,6 +13,8 @@
 #include "geometry.h"
 #include "point.h"
 
+#include "coordinates.h"
+
 RGEO_BEGIN_C
 
 
@@ -25,6 +27,28 @@ static VALUE method_point_geometry_type(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   if (self_data->geom) {
     result = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->feature_point;
+  }
+  return result;
+}
+
+
+static VALUE method_point_coordinates(VALUE self)
+{
+  VALUE result = Qnil;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  GEOSContextHandle_t context;
+  const GEOSCoordSequence* coord_sequence;
+
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+
+  if (self_geom) {
+    context = self_data->geos_context;
+    coord_sequence = GEOSGeom_getCoordSeq_r(context, self_geom);
+    if(coord_sequence) {
+      result = rb_ary_pop(extract_points_from_coordinate_sequence(context, coord_sequence));
+    }
   }
   return result;
 }
@@ -173,6 +197,7 @@ void rgeo_init_geos_point(RGeo_Globals* globals)
   rb_define_method(geos_point_methods, "y", method_point_y, 0);
   rb_define_method(geos_point_methods, "z", method_point_z, 0);
   rb_define_method(geos_point_methods, "m", method_point_m, 0);
+  rb_define_method(geos_point_methods, "coordinates", method_point_coordinates, 0);
 }
 
 

--- a/ext/geos_c_impl/point.c
+++ b/ext/geos_c_impl/point.c
@@ -39,15 +39,17 @@ static VALUE method_point_coordinates(VALUE self)
   const GEOSGeometry* self_geom;
   GEOSContextHandle_t context;
   const GEOSCoordSequence* coord_sequence;
+  int zCoordinate;
 
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
 
   if (self_geom) {
+    zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
     context = self_data->geos_context;
     coord_sequence = GEOSGeom_getCoordSeq_r(context, self_geom);
     if(coord_sequence) {
-      result = rb_ary_pop(extract_points_from_coordinate_sequence(context, coord_sequence));
+      result = rb_ary_pop(extract_points_from_coordinate_sequence(context, coord_sequence, zCoordinate));
     }
   }
   return result;

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -15,6 +15,8 @@
 #include "line_string.h"
 #include "polygon.h"
 
+#include "coordinates.h"
+
 RGEO_BEGIN_C
 
 
@@ -112,6 +114,27 @@ static VALUE method_polygon_point_on_surface(VALUE self)
   return result;
 }
 
+
+static VALUE method_polygon_coordinates(VALUE self)
+{
+  VALUE result = Qnil;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  GEOSContextHandle_t self_context;
+
+  GEOSGeometry* ring;
+  GEOSCoordSequence* coord_sequence;
+  unsigned int interior_ring_count;
+
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+
+  if (self_geom) {
+    self_context = self_data->geos_context;
+    result = extract_points_from_polygon(self_context, self_geom);
+  }
+  return result;
+}
 
 static VALUE method_polygon_exterior_ring(VALUE self)
 {
@@ -274,6 +297,7 @@ void rgeo_init_geos_polygon(RGeo_Globals* globals)
   rb_define_method(geos_polygon_methods, "num_interior_rings", method_polygon_num_interior_rings, 0);
   rb_define_method(geos_polygon_methods, "interior_ring_n", method_polygon_interior_ring_n, 1);
   rb_define_method(geos_polygon_methods, "interior_rings", method_polygon_interior_rings, 0);
+  rb_define_method(geos_polygon_methods, "coordinates", method_polygon_coordinates, 0);
 }
 
 

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -125,13 +125,15 @@ static VALUE method_polygon_coordinates(VALUE self)
   GEOSGeometry* ring;
   GEOSCoordSequence* coord_sequence;
   unsigned int interior_ring_count;
+  int zCoordinate;
 
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
 
   if (self_geom) {
+    zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
     self_context = self_data->geos_context;
-    result = extract_points_from_polygon(self_context, self_geom);
+    result = extract_points_from_polygon(self_context, self_geom, zCoordinate);
   }
   return result;
 }

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -364,6 +364,9 @@ module RGeo
       end
 
 
+      def coordinates
+        [x, y]
+      end
     end
 
 
@@ -441,6 +444,9 @@ module RGeo
       end
 
 
+      def coordinates
+        points.map &:coordinates
+      end
     end
 
 
@@ -543,6 +549,9 @@ module RGeo
       end
 
 
+      def coordinates
+        ([exterior_ring] + interior_rings).map &:coordinates
+      end
     end
 
 
@@ -631,6 +640,9 @@ module RGeo
       end
 
 
+      def coordinates
+        each.map &:coordinates
+      end
     end
 
 
@@ -656,6 +668,9 @@ module RGeo
       end
 
 
+      def coordinates
+        each.map &:coordinates
+      end
     end
 
 
@@ -682,6 +697,9 @@ module RGeo
       end
 
 
+      def coordinates
+        each.map &:coordinates
+      end
     end
 
 

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -365,7 +365,10 @@ module RGeo
 
 
       def coordinates
-        [x, y]
+        [x, y].tap do |coords|
+          coords << z if @factory.property(:has_z_coordinate)
+          coords << m if @factory.property(:has_m_coordinate)
+        end
       end
     end
 

--- a/lib/rgeo/geos/zm_feature_methods.rb
+++ b/lib/rgeo/geos/zm_feature_methods.rb
@@ -244,7 +244,12 @@ module RGeo
         @mgeometry.m
       end
 
-
+      def coordinates
+        [x, y].tap do |coords|
+          coords << z if @factory.property(:has_z_coordinate)
+          coords << m if @factory.property(:has_m_coordinate)
+        end
+      end
     end
 
 
@@ -296,7 +301,9 @@ module RGeo
         result_
       end
 
-
+      def coordinates
+        points.map &:coordinates
+      end
     end
 
 
@@ -344,6 +351,9 @@ module RGeo
       end
 
 
+      def coordinates
+        ([exterior_ring] + interior_rings).map &:coordinates
+      end
     end
 
 
@@ -388,6 +398,9 @@ module RGeo
       end
 
 
+      def coordinates
+        each.map &:coordinates
+      end
     end
 
 
@@ -409,6 +422,9 @@ module RGeo
       end
 
 
+      def coordinates
+        each.map &:coordinates
+      end
     end
 
 

--- a/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
+++ b/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
@@ -150,7 +150,9 @@ module RGeo
         factory.multi_point([array_])
       end
 
-
+      def coordinates
+        @elements.map &:coordinates
+      end
     end
 
 
@@ -179,6 +181,10 @@ module RGeo
         factory.collection([])
       end
 
+
+      def coordinates
+        @elements.map &:coordinates
+      end
 
     end
 
@@ -221,6 +227,9 @@ module RGeo
       end
 
 
+      def coordinates
+        @elements.map &:coordinates
+      end
     end
 
 

--- a/lib/rgeo/impl_helper/basic_line_string_methods.rb
+++ b/lib/rgeo/impl_helper/basic_line_string_methods.rb
@@ -117,6 +117,10 @@ module RGeo
       end
 
 
+      def coordinates
+        @points.map &:coordinates
+      end
+
     end
 
 
@@ -150,7 +154,9 @@ module RGeo
         Feature::Line
       end
 
-
+      def coordinates
+        @points.map &:coordinates
+      end
     end
 
 

--- a/lib/rgeo/impl_helper/basic_point_methods.rb
+++ b/lib/rgeo/impl_helper/basic_point_methods.rb
@@ -115,22 +115,11 @@ module RGeo
 
 
       def coordinates
-        [x, y]
-        # if factory.property(:has_z_coordinate)
-        #   if factory.property(:has_m_coordinate)
-        #     [x, y, z, m]
-        #   else
-        #     [x, y, z]
-        #   end
-        # else
-        #   if factory.property(:has_m_coordinate)
-        #     [x, y, m]
-        #   else
-        #     [x, y]
-        #   end
-        # end
+        [x, y].tap do |coords|
+          coords << z if factory.property(:has_z_coordinate)
+          coords << m if factory.property(:has_m_coordinate)
+        end
       end
-
     end
 
 

--- a/lib/rgeo/impl_helper/basic_point_methods.rb
+++ b/lib/rgeo/impl_helper/basic_point_methods.rb
@@ -114,6 +114,23 @@ module RGeo
       end
 
 
+      def coordinates
+        [x, y]
+        # if factory.property(:has_z_coordinate)
+        #   if factory.property(:has_m_coordinate)
+        #     [x, y, z, m]
+        #   else
+        #     [x, y, z]
+        #   end
+        # else
+        #   if factory.property(:has_m_coordinate)
+        #     [x, y, m]
+        #   else
+        #     [x, y]
+        #   end
+        # end
+      end
+
     end
 
 

--- a/lib/rgeo/impl_helper/basic_polygon_methods.rb
+++ b/lib/rgeo/impl_helper/basic_polygon_methods.rb
@@ -97,7 +97,9 @@ module RGeo
         @interior_rings = obj_.interior_rings
       end
 
-
+      def coordinates
+        ([@exterior_ring] + @interior_rings).map &:coordinates
+      end
     end
 
 

--- a/test/common/line_string_tests.rb
+++ b/test/common/line_string_tests.rb
@@ -337,6 +337,10 @@ module RGeo
           assert_equal(line1_, line2_)
         end
 
+        def test_linestring_coordinates
+          line = @factory.line_string([@factory.point(0.0, 1.0), @factory.point(2.0, 3.0)])
+          assert_equal(line.coordinates, [[0.0, 1.0], [2.0, 3.0]])
+        end
 
         if ::RGeo.yaml_supported?
 

--- a/test/common/multi_line_string_tests.rb
+++ b/test/common/multi_line_string_tests.rb
@@ -194,6 +194,10 @@ module RGeo
           assert_equal(0, geom2_.length)
         end
 
+        def test_coordinates
+          ml = @factory.multi_line_string([@linestring1, @linestring2])
+          assert_equal(ml.coordinates, [@linestring1, @linestring2].map(&:coordinates))
+        end
 
       end
 

--- a/test/common/multi_point_tests.rb
+++ b/test/common/multi_point_tests.rb
@@ -211,6 +211,15 @@ module RGeo
           assert_equal(p1_, mp_[0])
         end
 
+        def test_coordinate
+          p0 = @factory.point(0, 0)
+          p1 = @factory.point(1, 1)
+          p2 = @factory.point(2, 2)
+          points = [p0, p1, p2]
+          mp = @factory.multi_point(points)
+          assert_equal(mp.coordinates, points.map(&:coordinates))
+        end
+
 
       end
 

--- a/test/common/multi_polygon_tests.rb
+++ b/test/common/multi_polygon_tests.rb
@@ -6,7 +6,6 @@
 
 require 'rgeo'
 
-
 module RGeo
   module Tests  # :nodoc:
     module Common  # :nodoc:
@@ -185,7 +184,27 @@ module RGeo
           assert(geom2_.is_empty?)
         end
 
+        def test_multi_polygon_coordinates
+          poly1_coordinates = [
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]],
+            [[0.25, 0.25], [0.75, 0.25], [0.75, 0.75], [0.25, 0.75], [0.25, 0.25]]
+          ]
+          poly2_coordinates = [
+            [[2.0, 2.0], [3.0, 2.0], [3.0, 3.0], [2.0, 3.0], [2.0, 2.0]],
+            [[2.25, 2.25], [2.75, 2.25], [2.75, 2.75], [2.25, 2.75], [2.25, 2.25]]
+          ]
+          
+          ring = @factory.line_string(poly1_coordinates.first.map {|(x, y)| @factory.point x, y })
+          inner_ring = @factory.line_string(poly1_coordinates.last.map {|(x, y)| @factory.point x, y })
+          poly1 = @factory.polygon ring, [inner_ring]
 
+          ring = @factory.line_string(poly2_coordinates.first.map {|(x, y)| @factory.point x, y })
+          inner_ring = @factory.line_string(poly2_coordinates.last.map {|(x, y)| @factory.point x, y })
+          poly2 = @factory.polygon ring, [inner_ring]
+
+          multi_polygon = @factory.multi_polygon [poly1, poly2]
+          assert_equal(multi_polygon.coordinates, [poly1_coordinates, poly2_coordinates])
+        end
       end
 
     end

--- a/test/common/point_tests.rb
+++ b/test/common/point_tests.rb
@@ -361,6 +361,31 @@ module RGeo
           assert_equal([11.0, 12.0], point_.coordinates)
         end
 
+
+        def test_coordinates_3dz
+          point_ = @zfactory.point(11, 12, 13)
+          assert_equal([11.0, 12.0, 13.0], point_.coordinates)
+          point2_ = @zfactory.point(21, 22)
+          assert_equal([21.0, 22.0, 0.0], point2_.coordinates)
+        end
+
+
+        def test_coordinates_3dm
+          point_ = @mfactory.point(11, 12, 13)
+          assert_equal([11.0, 12.0, 13.0], point_.coordinates)
+          point2_ = @mfactory.point(21, 22)
+          assert_equal([21.0, 22.0, 0.0], point2_.coordinates)
+        end
+
+
+        def test_coordinates_4d
+          point_ = @zmfactory.point(11, 12, 13, 14)
+          assert_equal([11.0, 12.0, 13.0, 14.0], point_.coordinates)
+          point2_ = @zmfactory.point(21, 22)
+          assert_equal([21.0, 22.0, 0.0, 0.0], point2_.coordinates)
+        end
+
+
         if ::RGeo.yaml_supported?
 
           def test_psych_roundtrip

--- a/test/common/point_tests.rb
+++ b/test/common/point_tests.rb
@@ -356,6 +356,10 @@ module RGeo
           assert_equal(point_, point2_)
         end
 
+        def test_coordinates
+          point_ = @factory.point(11.0, 12.0)
+          assert_equal([11.0, 12.0], point_.coordinates)
+        end
 
         if ::RGeo.yaml_supported?
 

--- a/test/common/polygon_tests.rb
+++ b/test/common/polygon_tests.rb
@@ -230,6 +230,17 @@ module RGeo
         end
 
 
+        def test_polygon_coordinates
+          coordinates = [
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]],
+            [[0.25, 0.25], [0.75, 0.25], [0.75, 0.75], [0.25, 0.75], [0.25, 0.25]]
+          ]
+          
+          ring = @factory.line_string(coordinates.first.map {|(x, y)| @factory.point x, y })
+          inner_ring = @factory.line_string(coordinates.last.map {|(x, y)| @factory.point x, y })
+          polygon = @factory.polygon ring, [inner_ring]
+          assert_equal(polygon.coordinates, coordinates)
+        end
       end
 
     end

--- a/test/geos_capi/tc_line_string.rb
+++ b/test/geos_capi/tc_line_string.rb
@@ -16,17 +16,13 @@ module RGeo
 
       class TestLineString < ::Test::Unit::TestCase  # :nodoc:
 
+        include ::RGeo::Tests::Common::LineStringTests
 
         def setup
           @factory = ::RGeo::Geos.factory
         end
 
-
-        include ::RGeo::Tests::Common::LineStringTests
-
-
       end
-
     end
   end
 end if ::RGeo::Geos.capi_supported?

--- a/test/geos_capi/tc_multi_polygon.rb
+++ b/test/geos_capi/tc_multi_polygon.rb
@@ -41,7 +41,6 @@ module RGeo
           mp_.centroid.as_text
         end
 
-
       end
 
     end

--- a/test/geos_capi/tc_point.rb
+++ b/test/geos_capi/tc_point.rb
@@ -60,7 +60,6 @@ module RGeo
           assert_equal(2, point1_.distance(point3_))
         end
 
-
         if defined?(::Encoding)
 
           def test_as_text_encoding

--- a/test/geos_capi/tc_polygon.rb
+++ b/test/geos_capi/tc_polygon.rb
@@ -105,6 +105,7 @@ module RGeo
 
           assert_equal polygon, buffered_line_string
         end
+
       end
 
     end


### PR DESCRIPTION
This is a bit of the outcome from my digging into the performance problems I encountered with https://github.com/rgeo/rgeo/issues/116. I have also submitted a [PR](https://github.com/rgeo/rgeo-geojson/pull/16) to use `#coordinates` with `rgeo-geojson`.

Below are benchmarks for a CAPI multipolygon. I have not benchmarked any other the other implementations. 

```
factory_options = {
  srid: 4326,
  wkt_generator: { type_format: :ewkt, emit_ewkt_srid: true, convert_case: :upper },
  wkt_parser: { support_ewkt: true },
  wkb_generator:  { type_format: :ewkb, emit_ewkb_srid: true, hex_format: true },
  wkb_parser: { support_ewkb: true }
}

ewkb = "0106000020E6100000010000000103000000010000007B0000008A247A19C53C52C07B19A88C7FA54440392861A6ED3C52C043E4D70FB1A54440865451BCCA3C52C0D826F8A6E9A54440CC237F30F03C52C0838DCEF929A64440A6EB89AE0B3D52C0455B785E2AA64440D925AAB7063D52C063DEC66647A64440876A4AB20E3D52C0CB66F16261A6444079ABAE43353D52C01895B7239CA64440B2F336363B3D52C031DFDDCA12A7444034677DCA313D52C080FB1D8A02A7444071E7C2482F3D52C039F1B8A816A74440FE428F183D3D52C0FC2284471BA744401DC70F95463D52C00BB1DD3D40A74440EB5223F4333D52C0C6DFD91EBDA74440A5F5B704E03F52C0B3629B5434A84440F1D6F9B7CB3F52C0440229B16BA94440336DFFCA4A3F52C0FC70732A19AA44408849B890473F52C056CCEB8843AA444071C45A7C0A3F52C07601124DA0AA44401BF5108DEE3E52C009DB32E02CAB444021054F21573E52C02E41295AB9AB44405F420587173E52C0AC72840CE4AB4440FB3E1C24443E52C05A61DD7877AC44406D01A1F5F03D52C06F0A0E2F88AC4440BC1DE1B4E03D52C050F2CD3637AC444036936FB6B93D52C0D760C43E01AC44409D0E643DB53D52C030DB317557AC44408B321B64923D52C0E3D9C87553AC44407407B133853D52C08789E942ACAC444084622B685A3D52C01E5CE49EAEAC4440153AAFB14B3D52C0226C5B94D9AC44405260014C193D52C09326C11BD2AC44407FD767CEFA3C52C04FE08096AEAC44402F6D382C0D3D52C0C5E3857478AC4440E4141DC9E53C52C0DB4C689258AC44406E32AA0CE33C52C042478E7406AC4440039CDEC5FB3C52C0EACBB56801AC4440C5724BAB213D52C038F564FED1AB4440486E4DBA2D3D52C0EBE38409A3AB444074BD6DA6423D52C03AD0ED258DAB4440FFCEF6E80D3D52C00F6420CF2EAB44401077F52A323C52C02AB48F15FCAA4440D11F9A79723A52C011124C35B3AA44402593533BC33952C0FF349886E1A9444025CCB4FD2B3952C03D60014C19AA4440C3F01131253952C03348A46DFCA944400D022B87163952C03699D4D006AA4440077C7E18213952C0AF7B0E2C47AA4440320395F1EF3852C0F47E86376BAA4440A48D23D6E23852C0A1DFDA8992AA4440BF0CC688443852C03269368FC3AA444037312427133852C036D1CABDC0AA444024253D0CAD3752C046423EE8D9AA44406DA818E76F3752C06E902C6002AB444016DD7A4D0F3752C05BC79BFC16AB44400F41D5E8D53752C0A899D18F86A744407F4A95287B3852C04A1A868F88A544405A9D9CA1B83852C05AB72407ECA4444003763579CA3852C00D1ADD41ECA44440E2B6B6F0BC3852C08EEE0390DAA444408A4160E5D03852C00975745C8DA44440F64201DBC13852C09ED5E59480A044405320B3B3E83852C0DFDC425722A04440CAA7C7B60C3952C037581B6327A0444004E09F52253952C0EAE21934F49F444072A3C85A433952C028CE3461FB9F4440664CC11A673952C0E045425BCE9F4440DC9F8B868C3952C06CCEA44DD59F44406C97361C963952C025394371C79F444053211E89973952C0EFB3AD669D9F4440DA3D7958A83952C01A2E55698B9F4440CECCCCCCCC3952C03502D4D4B29F44406B459BE3DC3952C043B08D78B29F4440F1F3DF83D73952C00C5D6C5A29A04440E1ED4108C83952C06C8C800A47A04440B85A272EC73952C0ED3CD4B661A04440423EE8D9AC3952C0B6C9C4AD82A044401DC9E53FA43952C02BD653ABAFA044404D64E602973952C0E1D4EAABABA044405F8429CAA53952C00D382EE3A6A044400DE02D90A03952C0FEE7137992A04440A371A8DF853952C086ED0A7DB0A044404A44F817413952C07C662C9ACEA04440CA4C69FD2D3952C0DD845E7F12A14440996379573D3952C05356B60F79A144406E675F79903952C0984D637B2DA24440766B990CC73952C0D5C9FCA36FA244408B14CAC2D73952C066A180ED60A244402E573F36C93952C0E800A43671A244409F58A7CAF73952C090F9635A9BA24440DF516342CC3952C097AE433525A34440D172A087DA3952C04A5B3FFD67A34440D6AA5D13D23952C04BB2F1608BA344407329AE2AFB3952C00D4A7B832FA444400B5D8940F53A52C07484EFFD0DA44440630B410E4A3B52C0F14DB6813BA44440A417B5FB553B52C08DD3F36E2CA44440DD5CFC6D4F3B52C0656EA12B11A4444080F3E2C4573B52C02842CD902AA4444057E883656C3B52C0306117450FA4444067B45549643B52C0B98E54DFF9A34440AD156D8E733B52C0BA30B5A50EA44440B9E00CFE7E3B52C06298F6CDFDA34440571F0F7D773B52C06CB74082E2A3444091B8C7D2873B52C0277D04FEF0A344409811DE1E843B52C04F51D845D1A34440AD69DE718A3B52C083FC4FFEEEA3444023BA675DA33B52C03BE8F527F1A3444037A45181933B52C04B02B7EEE6A3444085B2F0F5B53B52C00E7F30F0DCA34440075DC2A1B73B52C042FCDF1115A4444049111956F13B52C0DDA276BF0AA4444086E5CFB7053C52C0E5484A7A18A444404B1E4FCB0F3C52C0C570581AF8A344400838842A353C52C02FF12A6B9BA4444062804413283C52C05282E15CC3A44440D15790662C3C52C059490ED8D5A44440B41A12F7583C52C03EA86E2EFEA444401536035C903C52C0B915A58460A5444031CD74AF933C52C06225C9737DA54440F6D1A92B9F3C52C044A4897780A544408B5242B0AA3C52C04C2B685A62A544408A247A19C53C52C07B19A88C7FA54440";''

capi_factory = RGeo::Geos.factory(factory_options)

capi_parser = RGeo::WKRep::WKBParser.new(capi_factory, support_ewkb: true)

multi_polygon = capi_factory.parse_wkb(ewkb)

point_encoder = ::Proc.new{ |p| [p.x, p.y] }

Benchmark.ips do |x|

  x.report("new coordinates method") do
    multi_polygon.coordinates
  end

  x.report("old style from rgeo-geojson gem") do
    multi_polygon.map{ |poly| [poly.exterior_ring.points.map(&point_encoder)] + poly.interior_rings.map{ |r_| r_.points.map(&point_encoder) } }
  end

  x.compare!
end
```

```
Calculating -------------------------------------
new coordinates method
                         4.820k i/100ms
old style from rgeo-geojson gem
                       514.000  i/100ms
-------------------------------------------------
new coordinates method
                         62.242k (± 5.8%) i/s -    313.300k
old style from rgeo-geojson gem
                          6.122k (±31.7%) i/s -     27.242k

Comparison:
new coordinates method:    62241.8 i/s
old style from rgeo-geojson gem:     6122.5 i/s - 10.17x slower
```