### PR TITLE
Permit .each() to not recieve a block, but return an enumerator

### DIFF
--- a/lib/rgeo/geos/zm_feature_methods.rb
+++ b/lib/rgeo/geos/zm_feature_methods.rb
@@ -301,8 +301,13 @@ module RGeo
       alias_method :[], :geometry_n
 
       def each
-        num_geometries.times do |i_|
-          yield geometry_n(i_)
+        if block_given?
+          num_geometries.times do |i_|
+            yield geometry_n(i_)
+          end
+          self
+        else
+          enum_for
         end
       end
 


### PR DESCRIPTION
Investigating rgeo/rgeo-geojson#22 I noticed that elsewhere in the codebase, `.each` checks for `block_given?`, and returns an enumerator if not. The `coordinates` method that was at the top of the stacktrace in the presenting issue expects this. The attached fix is to explicitly check for `block_given?` in the `each` method of `ZMGeometryCollectionMethods`. 

I couldn't find where tests the tests for this particular model are located, so this PR doesn't include updated test cases, sorry. I'm happy to add some tests if you can suggest where I should put them.
