### PR TITLE
Remove duplicate points when casting rings+lines

### DIFF
--- a/lib/rgeo/feature/types.rb
+++ b/lib/rgeo/feature/types.rb
@@ -246,11 +246,11 @@ module RGeo
             end
           elsif ntype_ == LinearRing
             if type_ == LineString
-              nfactory_.linear_ring(obj_.points.map { |p_| cast(p_, nfactory_, opts_) })
+              nfactory_.linear_ring(obj_.points.chunk{|x| x}.map(&:first).map { |p_| cast(p_, nfactory_, opts_) })
             end
           elsif ntype_ == LineString
             if type_ == Line || type_ == LinearRing
-              nfactory_.line_string(obj_.points.map { |p_| cast(p_, nfactory_, opts_) })
+              nfactory_.line_string(obj_.points.chunk{|x| x}.map(&:first).map { |p_| cast(p_, nfactory_, opts_) })
             end
           elsif ntype_ == MultiPoint
             if type_ == Point


### PR DESCRIPTION
I ran into a similar issue like #113, so I made this fix.  If you'd like it behind a config parameter or other changes, feel free to let me know.

Here's a polygon that chokes RGeo:  `'MULTIPOLYGON(((-122.10033416748 37.6906110800046,-122.10033416748 37.6906110800046,-122.075443267822 37.6911544368997,-122.075443267822 37.6911544368997,-122.057418823242 37.6933278246668,-122.057418823242 37.6933278246668,-122.045230865479 37.6956369793712,-122.045230865479 37.6956369793712,-122.046947479248 37.6899334219492,-122.033815383911 37.6705735585369,-122.015447616577 37.675329080766,-122.034072875977 37.7018849197626,-122.034072875977 37.7018849197626,-122.00626373291 37.7126153927168,-122.045917510986 37.7423479509276,-122.045917510986 37.7423479509276,-122.111663818359 37.7352888797979,-122.111663818359 37.7352888797979,-122.120418548584 37.7071816741417,-122.120418548584 37.7071816741417,-122.107887268066 37.6997117828282,-122.107887268066 37.6997117828282,-122.10033416748 37.6906110800046)))'`
