### PR TITLE
node geometry collection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+dist: trusty
 sudo: false
 addons:
   apt:
     packages:
-    - libgeos-3.4.0
+    - libgeos-3.4.2
     - libproj-dev
 language: ruby
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 addons:
   apt:
     packages:
-    - libgeos-3.3.8
+    - libgeos-3.4.0
     - libproj-dev
 language: ruby
 rvm:

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -363,6 +363,23 @@ static VALUE method_multi_line_string_hash(VALUE self)
   return LONG2FIX(rb_hash_end(hash));
 }
 
+static VALUE method_geometry_collection_node(VALUE self)
+{
+  VALUE result = Qnil;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  GEOSGeometry* noded;
+  GEOSContextHandle_t context;
+
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+  context = self_data->geos_context;
+
+  noded = GEOSNode_r(context, self_geom);
+  result = rgeo_wrap_geos_geometry(self_data->factory, noded, Qnil);
+
+  return result;
+}
 
 static VALUE method_multi_line_string_coordinates(VALUE self)
 {
@@ -609,6 +626,7 @@ void rgeo_init_geos_geometry_collection(RGeo_Globals* globals)
   rb_define_method(geos_geometry_collection_methods, "geometry_n", method_geometry_collection_geometry_n, 1);
   rb_define_method(geos_geometry_collection_methods, "[]", method_geometry_collection_brackets, 1);
   rb_define_method(geos_geometry_collection_methods, "each", method_geometry_collection_each, 0);
+  rb_define_method(geos_geometry_collection_methods, "node", method_geometry_collection_node, 0);
 
 
   // Methods for MultiPointImpl

--- a/lib/rgeo/feature/geometry_collection.rb
+++ b/lib/rgeo/feature/geometry_collection.rb
@@ -80,6 +80,12 @@ module RGeo
         raise Error::UnsupportedOperation, "Method GeometryCollection#[] not defined."
       end
 
+      # Nodes the linework in a list of Geometries
+      #
+      def node
+        raise Error::UnsupportedOperation, "Method GeometryCollection#node not defined."
+      end
+
       # Iterates over the geometries of this GeometryCollection.
       #
       # This is not a standard SFS method, but is provided so that a

--- a/test/geos_capi/geometry_collection_test.rb
+++ b/test/geos_capi/geometry_collection_test.rb
@@ -17,6 +17,26 @@ module RGeo
           ::RGeo::Geos.factory
         end
 
+        def test_collection_node
+          lines = [ [[0,0], [0,2]], [[-1,1], [1,1]] ]
+            .map { |p1,p2| [@factory.point(*p1), @factory.point(*p2)] }
+            .map { |p1,p2| @factory.line(p1,p2) }
+
+          multi = @factory.multi_line_string(lines)
+
+          expected_lines = [
+              [ [0,0],  [0,1] ],
+              [ [0,1],  [0,2] ],
+              [ [-1,1], [0,1] ],
+              [ [0,1],  [1,1] ]
+            ].map { |p1, p2| @factory.line(@factory.point(*p1), @factory.point(*p2)) }
+
+          noded = multi.node
+
+          assert_equal(noded.count, 4)
+          assert_true(expected_lines.all? { |line| noded.include? line })
+        end
+
         include ::RGeo::Tests::Common::GeometryCollectionTests
       end
     end


### PR DESCRIPTION
A project I'm working on requires the intersections in a MultiLineString be noded for processing.
This functionality from the GEOS C interface was not exposed.  This PR allows for the a call
to #node on geometry collection types resulting in a noded version.
