### PR TITLE
Remove exception catching

### DIFF
--- a/lib/rgeo/cartesian/factory.rb
+++ b/lib/rgeo/cartesian/factory.rb
@@ -28,11 +28,7 @@ module RGeo
         srid = opts[:srid]
         @coord_sys = opts[:coord_sys]
         if @coord_sys.is_a?(::String)
-          @coord_sys = begin
-                         CoordSys::CS.create_from_wkt(@coord_sys)
-                       rescue
-                         nil
-                       end
+          @coord_sys = CoordSys::CS.create_from_wkt(@coord_sys)
         end
         if (!@proj4 || !@coord_sys) && srid && (db = opts[:srs_database])
           entry = db.get(srid.to_i)

--- a/lib/rgeo/cartesian/factory.rb
+++ b/lib/rgeo/cartesian/factory.rb
@@ -225,72 +225,54 @@ module RGeo
 
       def point(x, y, *extra)
         PointImpl.new(self, x, y, *extra)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#line_string
 
       def line_string(points)
         LineStringImpl.new(self, points)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#line
 
       def line(start, stop)
         LineImpl.new(self, start, stop)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#linear_ring
 
       def linear_ring(points)
         LinearRingImpl.new(self, points)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#polygon
 
       def polygon(outer_ring, inner_rings = nil)
         PolygonImpl.new(self, outer_ring, inner_rings)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#collection
 
       def collection(elems)
         GeometryCollectionImpl.new(self, elems)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#multi_point
 
       def multi_point(elems)
         MultiPointImpl.new(self, elems)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#multi_line_string
 
       def multi_line_string(elems)
         MultiLineStringImpl.new(self, elems)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#multi_polygon
 
       def multi_polygon(elems)
         MultiPolygonImpl.new(self, elems)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#proj4

--- a/lib/rgeo/feature/types.rb
+++ b/lib/rgeo/feature/types.rb
@@ -236,7 +236,7 @@ module RGeo
               cast(obj.geometry_n(0), nfactory, ntype, opts)
             end
           elsif ntype == Point
-            nil
+            raise(Error::InvalidGeometry, "Cannot cast to Point")
           elsif ntype == Line
             if type == LineString && obj.num_points == 2
               nfactory.line(cast(obj.point_n(0), nfactory, opts), cast(obj.point_n(1), nfactory, opts))
@@ -273,6 +273,8 @@ module RGeo
             else
               nfactory.collection([cast(obj, nfactory, opts)])
             end
+          else
+            raise(RGeo::Error::InvalidGeometry, "Undefined type cast from #{type.name} to #{ntype.name}")
           end
         end
       end

--- a/lib/rgeo/geographic/factory.rb
+++ b/lib/rgeo/geographic/factory.rb
@@ -141,11 +141,7 @@ module RGeo
           coord_sys: coord_sys
                   )
         if (proj_klass = data_["prjc"]) && (proj_factory = data_["prjf"])
-          klass_ = begin
-                     RGeo::Geographic.const_get(proj_klass)
-                   rescue
-                     nil
-                   end
+          klass_ = RGeo::Geographic.const_get(proj_klass)
           if klass_
             projector = klass_.allocate
             projector.set_factories(self, proj_factory)
@@ -208,11 +204,7 @@ module RGeo
           coord_sys: coord_sys
                   )
         if (proj_klass = coder["projectorclass"]) && (proj_factory = coder["projection_factory"])
-          klass_ = begin
-                     RGeo::Geographic.const_get(proj_klass)
-                   rescue
-                     nil
-                   end
+          klass_ = RGeo::Geographic.const_get(proj_klass)
           if klass_
             projector = klass_.allocate
             projector.set_factories(self, proj_factory)

--- a/lib/rgeo/geographic/factory.rb
+++ b/lib/rgeo/geographic/factory.rb
@@ -327,72 +327,54 @@ module RGeo
 
       def point(x, y, *extra)
         @point_class.new(self, x, y, *extra)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#line_string
 
       def line_string(points)
         @line_string_class.new(self, points)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#line
 
       def line(start, stop)
         @line_class.new(self, start, stop)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#linear_ring
 
       def linear_ring(points)
         @linear_ring_class.new(self, points)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#polygon
 
       def polygon(outer_ring, inner_rings = nil)
         @polygon_class.new(self, outer_ring, inner_rings)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#collection
 
       def collection(elems)
         @geometry_collection_class.new(self, elems)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#multi_point
 
       def multi_point(elems)
         @multi_point_class.new(self, elems)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#multi_line_string
 
       def multi_line_string(elems)
         @multi_line_string_class.new(self, elems)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#multi_polygon
 
       def multi_polygon(elems)
         @multi_polygon_class.new(self, elems)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#proj4

--- a/lib/rgeo/geographic/factory.rb
+++ b/lib/rgeo/geographic/factory.rb
@@ -37,11 +37,7 @@ module RGeo
         end
         @coord_sys = opts[:coord_sys]
         if @coord_sys.is_a?(::String)
-          @coord_sys = begin
-                         CoordSys::CS.create_from_wkt(@coord_sys)
-                       rescue
-                         nil
-                       end
+          @coord_sys = CoordSys::CS.create_from_wkt(@coord_sys)
         end
         @lenient_assertions = opts[:uses_lenient_assertions] ? true : false
         @buffer_resolution = opts[:buffer_resolution].to_i

--- a/lib/rgeo/geos/capi_factory.rb
+++ b/lib/rgeo/geos/capi_factory.rb
@@ -302,13 +302,9 @@ module RGeo
 
       def point(x_, y_, *extra_)
         if extra_.length > (_flags & 6 == 0 ? 0 : 1)
-          nil
+          raise(RGeo::Error::InvalidGeometry, "Parse error")
         else
-          begin
-            CAPIPointImpl.create(self, x_, y_, extra_[0].to_f)
-          rescue
-            nil
-          end
+          CAPIPointImpl.create(self, x_, y_, extra_[0].to_f)
         end
       end
 
@@ -316,85 +312,57 @@ module RGeo
 
       def line_string(points_)
         points_ = points_.to_a unless points_.is_a?(::Array)
-        begin
-          CAPILineStringImpl.create(self, points_)
-        rescue
-          nil
-        end
+        CAPILineStringImpl.create(self, points_) ||
+          raise(RGeo::Error::InvalidGeometry, "Parse error")
       end
 
       # See RGeo::Feature::Factory#line
 
       def line(start_, end_)
         CAPILineImpl.create(self, start_, end_)
-      rescue
-        nil
       end
 
       # See RGeo::Feature::Factory#linear_ring
 
       def linear_ring(points_)
         points_ = points_.to_a unless points_.is_a?(::Array)
-        begin
-          CAPILinearRingImpl.create(self, points_)
-        rescue
-          nil
-        end
+        CAPILinearRingImpl.create(self, points_)
       end
 
       # See RGeo::Feature::Factory#polygon
 
       def polygon(outer_ring_, inner_rings_ = nil)
         inner_rings_ = inner_rings_.to_a unless inner_rings_.is_a?(::Array)
-        begin
-          CAPIPolygonImpl.create(self, outer_ring_, inner_rings_)
-        rescue
-          nil
-        end
+        CAPIPolygonImpl.create(self, outer_ring_, inner_rings_)
       end
 
       # See RGeo::Feature::Factory#collection
 
       def collection(elems_)
         elems_ = elems_.to_a unless elems_.is_a?(::Array)
-        begin
-          CAPIGeometryCollectionImpl.create(self, elems_)
-        rescue
-          nil
-        end
+        CAPIGeometryCollectionImpl.create(self, elems_)
       end
 
       # See RGeo::Feature::Factory#multi_point
 
       def multi_point(elems_)
         elems_ = elems_.to_a unless elems_.is_a?(::Array)
-        begin
-          CAPIMultiPointImpl.create(self, elems_)
-        rescue
-          nil
-        end
+        CAPIMultiPointImpl.create(self, elems_)
       end
 
       # See RGeo::Feature::Factory#multi_line_string
 
       def multi_line_string(elems_)
         elems_ = elems_.to_a unless elems_.is_a?(::Array)
-        begin
-          CAPIMultiLineStringImpl.create(self, elems_)
-        rescue
-          nil
-        end
+        CAPIMultiLineStringImpl.create(self, elems_)
       end
 
       # See RGeo::Feature::Factory#multi_polygon
 
       def multi_polygon(elems_)
         elems_ = elems_.to_a unless elems_.is_a?(::Array)
-        begin
-          CAPIMultiPolygonImpl.create(self, elems_)
-        rescue
-          nil
-        end
+        CAPIMultiPolygonImpl.create(self, elems_) ||
+          raise(RGeo::Error::InvalidGeometry, "Parse error")
       end
 
       # See RGeo::Feature::Factory#proj4

--- a/lib/rgeo/geos/capi_factory.rb
+++ b/lib/rgeo/geos/capi_factory.rb
@@ -67,11 +67,7 @@ module RGeo
           end
           coord_sys_ = opts_[:coord_sys]
           if coord_sys_.is_a?(::String)
-            coord_sys_ = begin
-                           CoordSys::CS.create_from_wkt(coord_sys_)
-                         rescue
-                           nil
-                         end
+            coord_sys_ = CoordSys::CS.create_from_wkt(coord_sys_)
           end
           if (!proj4_ || !coord_sys_) && srid_ && (db_ = opts_[:srs_database])
             entry_ = db_.get(srid_.to_i)

--- a/lib/rgeo/geos/ffi_factory.rb
+++ b/lib/rgeo/geos/ffi_factory.rb
@@ -68,11 +68,7 @@ module RGeo
         end
         @coord_sys = opts[:coord_sys]
         if @coord_sys.is_a?(::String)
-          @coord_sys = begin
-                         CoordSys::CS.create_from_wkt(@coord_sys)
-                       rescue
-                         nil
-                       end
+          @coord_sys = CoordSys::CS.create_from_wkt(@coord_sys)
         end
         if (!@proj4 || !@coord_sys) && @srid && (db = opts[:srs_database])
           entry = db.get(@srid.to_i)

--- a/test/common/line_string_tests.rb
+++ b/test/common/line_string_tests.rb
@@ -12,7 +12,6 @@ module RGeo
           point1 = @factory.point(0, 0)
           point2 = @factory.point(0, 1)
           line1 = @factory.line_string([point1, point2])
-          assert_not_nil(line1)
           assert_equal(RGeo::Feature::LineString, line1.geometry_type)
           assert_equal(2, line1.num_points)
           assert_equal(point1, line1.point_n(0))
@@ -101,10 +100,12 @@ module RGeo
         def test_creation_errors
           point1 = @factory.point(0, 0)
           collection = point1.boundary
-          line1 = @factory.line_string([point1])
-          assert_nil(line1)
-          line2 = @factory.line_string([point1, collection])
-          assert_nil(line2)
+          assert_raise(RGeo::Error::InvalidGeometry) do
+            @factory.line_string([point1])
+          end
+          assert_raise(RGeo::Error::InvalidGeometry) do
+            @factory.line_string([point1, collection])
+          end
         end
 
         def test_required_equivalences

--- a/test/common/multi_point_tests.rb
+++ b/test/common/multi_point_tests.rb
@@ -51,8 +51,9 @@ module RGeo
 
         def test_creation_wrong_type
           line = @factory.line_string([@point1, @point2])
-          geom = @factory.multi_point([@point3, line])
-          assert_nil(geom)
+          assert_raise(RGeo::Error::InvalidGeometry) do
+            @factory.multi_point([@point3, line])
+          end
         end
 
         def test_required_equivalences

--- a/test/common/multi_polygon_tests.rb
+++ b/test/common/multi_polygon_tests.rb
@@ -51,22 +51,25 @@ module RGeo
         end
 
         def test_creation_wrong_type
-          geom = @factory.multi_polygon([@poly1, @line1])
-          assert_nil(geom)
+          assert_raise(RGeo::Error::InvalidGeometry) do
+            @factory.multi_polygon([@poly1, @line1])
+          end
         end
 
         def test_creation_overlapping
-          geom = @factory.multi_polygon([@poly1, @poly1])
-          assert_nil(geom)
-          geom2 = @lenient_factory.multi_polygon([@poly1, @poly1])
-          assert_not_nil(geom2)
+          assert_raise(RGeo::Error::InvalidGeometry) do
+            @factory.multi_polygon([@poly1, @poly1])
+          end
+          geom = @lenient_factory.multi_polygon([@poly1, @poly1])
+          assert_equal RGeo::Feature::MultiPolygon, geom.geometry_type
         end
 
         def test_creation_connected
-          geom = @factory.multi_polygon([@poly3, @poly4])
-          assert_nil(geom)
-          geom2 = @lenient_factory.multi_polygon([@poly3, @poly4])
-          assert_not_nil(geom2)
+          assert_raise(RGeo::Error::InvalidGeometry) do
+            @factory.multi_polygon([@poly3, @poly4])
+          end
+          geom = @lenient_factory.multi_polygon([@poly3, @poly4])
+          assert_equal RGeo::Feature::MultiPolygon, geom.geometry_type
         end
 
         def test_required_equivalences


### PR DESCRIPTION
When parsing objects, let them raise an exception rather than silently returning nil.

#158 #47 