### PR TITLE
 fix Cartesian::Analysis.ring_direction bug

### DIFF
--- a/lib/rgeo/cartesian/analysis.rb
+++ b/lib/rgeo/cartesian/analysis.rb
@@ -51,10 +51,11 @@ module RGeo
           # Now add the angles and count revolutions.
           # Again, our running sum is represented as a cos/sin pair.
           revolutions = 0
+          direction = nil
           sin = 0.0
           cos = 1.0
           angs.each_slice(2) do |(x, y)|
-            ready = y > 0.0 && sin > 0.0 || y < 0.0 && sin < 0.0
+            ready = y > 0.0 && (sin > 0.0 || sin == 0.0 && direction == -1) || y < 0.0 && (sin < 0.0 || sin == 0.0 && direction == 1)
             if y != 0.0
               s = sin * x + cos * y
               c = cos * x - sin * y
@@ -65,8 +66,10 @@ module RGeo
             next unless ready
             if y > 0.0 && sin <= 0.0
               revolutions += 1
+              direction = 1
             elsif y < 0.0 && sin >= 0.0
               revolutions -= 1
+              direction = -1
             end
           end
           revolutions

--- a/test/cartesian_analysis_test.rb
+++ b/test/cartesian_analysis_test.rb
@@ -45,6 +45,28 @@ class CartesianAnalysisTest < Test::Unit::TestCase # :nodoc:
     assert_equal(1, RGeo::Cartesian::Analysis.ring_direction(ring))
   end
 
+  def test_ring_direction_clockwise_hat
+    p1 = @factory.point(1, 2)
+    p2 = @factory.point(2, 3)
+    p3 = @factory.point(3, 2)
+    p4 = @factory.point(2, 1)
+    p5 = @factory.point(2, 0)
+    p6 = @factory.point(0, 2)
+    ring = @factory.line_string([p1, p2, p3, p4, p5, p6, p1])
+    assert_equal(-1, RGeo::Cartesian::Analysis.ring_direction(ring))
+  end
+
+  def test_ring_direction_counterclockwise_hat
+    p1 = @factory.point(2, 1)
+    p2 = @factory.point(3, 2)
+    p3 = @factory.point(2, 3)
+    p4 = @factory.point(1, 2)
+    p5 = @factory.point(0, 2)
+    p6 = @factory.point(2, 0)
+    ring = @factory.line_string([p1, p2, p3, p4, p5, p6, p1])
+    assert_equal(1, RGeo::Cartesian::Analysis.ring_direction(ring))
+  end
+
   def test_ring_direction_counterclockwise_near_circle
     p1 = @factory.point(0, -3)
     p2 = @factory.point(2, -2)


### PR DESCRIPTION
To tell whether the points in a ring goes clockwise or counterclockwise, Cartesian::Analysis.ring_direction iterates through all point in the ring, keeping track of an angle (as a cos/sin pair) that represents the amount of rotation that has been seen thus far. Whenever the angle goes across the 180 degree boundary (where sin = 0 and cos = -1), the revolutions variable should be incremented/decremented to track how many times the boundary has been crossed in which direction.

There is a bug that occurs when the angle tracking rotation lands exactly on the 180 degree boundary, then moves back to the same side of the boundary it was on before landing on the boundary. The revolutions variable is incremented/decremented when the boundary is hit, but this change is not undone when the angle moves back to the same side.

To demonstrate this, I created a new test case using the ring [(1, 2), (3, 2), (2, 3), (1, 2), (0, 2), (2, 0)].

The angle starts as sin = 0, cos = 1.

On the 1st iteration, the angle between (1, 2), (3, 2), and (2, 3) is used, bringing us to sin = 1, cos = 0.

On the 2nd iteration, the angle between (3, 2), (2, 3), and (1, 2) is used, bringing us to sin = 0, cos = -1. The revolutions variable is incremented from 0 to 1.

On the 3rd iteration, the angle between (2, 3), (1, 2), and (0, 2) is used, bringing us to sin = 0.707, cos = -0.707. In the original code, the revolutions variable is not changed. In the new code, the revolutions variable is decremented from 1 to 0.

On the 4th iteration, the angle between (1, 2), (0, 2), and (2, 0) is used, bringing us to sin = -1, cos = 0. In the original code, the revolutions variable is incremented from 1 to 2. In the new code, the revolutions variable is incremented from 0 to 1.