### PR TITLE
longitude of 180 raises uninitialized constant RGeo::Geographic::ProjectedPointMethods::PointImpl

### DIFF
--- a/lib/rgeo/geographic/projected_feature_methods.rb
+++ b/lib/rgeo/geographic/projected_feature_methods.rb
@@ -125,7 +125,7 @@ module RGeo
         if @x >= -180.0 && @x < 180.0
           self
         else
-          PointImpl.new(@factory, canonical_x, @y)
+          ProjectedPointImpl.new(@factory, canonical_x, @y)
         end
       end
 

--- a/test/simple_cartesian/point_test.rb
+++ b/test/simple_cartesian/point_test.rb
@@ -29,6 +29,18 @@ class CartesianPointTest < Minitest::Test # :nodoc:
     assert_in_delta(13, point1.distance(point2), 0.0001)
   end
 
+  def test_lon_180
+    factory = RGeo::Geographic.simple_mercator_factory
+    points = [
+      [48.02006, -179.47466],
+      [48.00986, -179.7496],
+      [48.00000, 180.0]
+    ].map { |coord| factory.point(coord[1], coord[0]) }
+
+    assert_equal "LINESTRING (-179.47466 48.02006, -179.7496 48.00986, 180.0 48.0)",
+      factory.line_string(points).to_s
+  end
+
   undef_method :test_disjoint
   undef_method :test_intersects
   undef_method :test_touches


### PR DESCRIPTION
I'm creating geojson from an upstream source of lat/lon values and using  `::RGeo::Geographic.simple_mercator_factory`. When a longitude value is `180` I see ` uninitialized constant RGeo::Geographic::ProjectedPointMethods::PointImpl (NameError)`

### Steps to reproduce
I've reduced the issue to the following test script which will reliably generate the error with ruby 2.5.3 and rgeo 2.0.0.  

```
#!/usr/bin/env ruby

require 'rgeo'

orig_points = [
  {lat: 48.02006, lon: -179.47466 },
  {lat: 48.00986, lon: -179.7496  },
  {lat: 48.0    , lon:  180.0     },
]

factory = ::RGeo::Geographic.simple_mercator_factory

factory_points = orig_points.map{ |op| factory.point(op[:lon], op[:lat]) }
line_string    = factory.line_string(factory_points)
```

### Actual behavior

```
Traceback (most recent call last):
        6: from x.rb:14:in `<main>'
        5: from ruby/2.5.3/gems/rgeo-2.0.0/lib/rgeo/geographic/factory.rb:326:in `line_string'
        4: from ruby/2.5.3/gems/rgeo-2.0.0/lib/rgeo/geographic/factory.rb:326:in `new'
        3: from ruby/2.5.3/gems/rgeo-2.0.0/lib/rgeo/impl_helper/basic_line_string_methods.rb:19:in `initialize'
        2: from ruby/2.5.3/gems/rgeo-2.0.0/lib/rgeo/geographic/projected_feature_methods.rb:160:in `validate_geometry'
        1: from ruby/2.5.3/gems/rgeo-2.0.0/lib/rgeo/geographic/projected_feature_methods.rb:160:in `map'
ruby/2.5.3/gems/rgeo-2.0.0/lib/rgeo/geographic/projected_feature_methods.rb:128:in `canonical_point': uninitialized constant RGeo::Geographic::ProjectedPointMethods::PointImpl (NameError)
```

### Debugging

I've traced this down to https://github.com/rgeo/rgeo/blob/c80af4f43c1b4da275d5672599e8a8910694755c/lib/rgeo/geographic/projected_feature_methods.rb#L124-L130

and `PointImpl` is not defined at this point. At least in the way I am using this. And I could be using this incorrectly. If I change `PointImpl` to `ProjectedPointImpl` then It works and I get a resulting GeoJSON output.

### System configuration

**Ruby version**:

`ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-darwin18]`

**OS**:
This happens on OSX Mojave, and on Ubuntu 18.04.2 LTS 
