### PR TITLE
Efficient WKB string detection

### DIFF
--- a/lib/rgeo/geos/capi_factory.rb
+++ b/lib/rgeo/geos/capi_factory.rb
@@ -297,10 +297,10 @@ module RGeo
         if (wkb_parser_ = _wkb_parser)
           wkb_parser_.parse(str_)
         else
-          if str_[0] =~ /[0-oa-fA-F]/
-            _parse_wkb_impl([str_].pack('H*'))
-          else
+          if str_[0] == "\x00" || str_[0] == "\x01"
             _parse_wkb_impl(str_)
+          else
+            _parse_wkb_impl([str_].pack('H*'))
           end
         end
       end


### PR DESCRIPTION
### Summary

WKB binary string always starts with `\x00` or `\x01`.
> The first byte indicates the byte order. 00 for big endian, or 01 for little endian.
> https://mariadb.com/kb/en/library/well-known-binary-wkb-format/

So, it would be more efficient to detect binary WKB string this way:
```ruby
str_[0] == "\x00" || str_[0] == "\x01" 
```

Similar way of detection used in https://github.com/rgeo/activerecord-postgis-adapter/blob/744bed7e276135be83ebfb6c498273766f918850/lib/active_record/connection_adapters/postgis/oid/spatial.rb#L99.

Also, there was a typo with `/[0-oa-fA-F]/` instead of `/[0-9a-fA-F]/`.
