### PR TITLE
Add centroid calculation for spherical polygons

### DIFF
--- a/lib/rgeo/geographic/spherical_feature_classes.rb
+++ b/lib/rgeo/geographic/spherical_feature_classes.rb
@@ -47,6 +47,7 @@ module RGeo
       include ImplHelper::BasicGeometryMethods
       include ImplHelper::BasicPolygonMethods
       include SphericalGeometryMethods
+      include SphericalPolygonMethods
     end
 
     class SphericalGeometryCollectionImpl # :nodoc:

--- a/lib/rgeo/geographic/spherical_feature_methods.rb
+++ b/lib/rgeo/geographic/spherical_feature_methods.rb
@@ -135,23 +135,15 @@ module RGeo
       def centroid
         return super unless num_interior_rings == 0
 
-        points = coordinates.first
-
         centroid_lat = 0.0
         centroid_lng = 0.0
         signed_area = 0.0
 
-        # Iterate over each element in the list but the last item as it's
-        # calculated by the i+1 logic
-        points[0...-1].each_index do |i|
-          x0 = points[i][0]
-          y0 = points[i][1]
-          x1 = points[i + 1][0]
-          y1 = points[i + 1][1]
-          a = (x0 * y1) - (x1 * y0)
-          signed_area += a
-          centroid_lat += (x0 + x1) * a
-          centroid_lng += (y0 + y1) * a
+        exterior_ring.points.each_cons(2) do |p0, p1|
+          area = (p0.x * p1.y) - (p1.x * p0.y)
+          signed_area += area
+          centroid_lat += (p0.x + p1.x) * area
+          centroid_lng += (p0.y + p1.y) * area
         end
 
         signed_area *= 0.5

--- a/lib/rgeo/geographic/spherical_feature_methods.rb
+++ b/lib/rgeo/geographic/spherical_feature_methods.rb
@@ -130,5 +130,36 @@ module RGeo
         inject(0.0) { |sum, geom| sum + geom.length }
       end
     end
+
+    module SphericalPolygonMethods # :nodoc:
+      def centroid
+        return super unless num_interior_rings == 0
+
+        points = coordinates.first
+
+        centroid_lat = 0.0
+        centroid_lng = 0.0
+        signed_area = 0.0
+
+        # Iterate over each element in the list but the last item as it's
+        # calculated by the i+1 logic
+        points[0...-1].each_index do |i|
+          x0 = points[i][0]
+          y0 = points[i][1]
+          x1 = points[i + 1][0]
+          y1 = points[i + 1][1]
+          a = (x0 * y1) - (x1 * y0)
+          signed_area += a
+          centroid_lat += (x0 + x1) * a
+          centroid_lng += (y0 + y1) * a
+        end
+
+        signed_area *= 0.5
+        centroid_lat /= (6.0 * signed_area)
+        centroid_lng /= (6.0 * signed_area)
+
+        RGeo::Geographic.spherical_factory.point(centroid_lat, centroid_lng)
+      end
+    end
   end
 end

--- a/test/spherical_geographic/polygon_test.rb
+++ b/test/spherical_geographic/polygon_test.rb
@@ -19,4 +19,13 @@ class SphericalPolygonTest < Minitest::Test # :nodoc:
   undef_method :test_geometrically_equal_but_ordered_different
   undef_method :test_geometrically_equal_but_different_directions
   undef_method :test_point_on_surface
+
+  def test_centroid
+    point1 = @factory.point(0, 0)
+    point2 = @factory.point(0, 1)
+    point3 = @factory.point(1, 0)
+    exterior = @factory.linear_ring([point1, point2, point3, point1])
+    polygon = @factory.polygon(exterior)
+    assert_equal @factory.point(1.0/3.0, 1.0/3.0), polygon.centroid
+  end
 end


### PR DESCRIPTION
### Summary

Implement `centroid` for SphericalPolygon. Resolves #142.

### Other Information

This logic is borrowed directly from [geokit](https://github.com/geokit/geokit) with modifications to accommodate rgeo data structures. Note that the calculation assumes Euclidian geometry, which will become increasingly inaccurate as the size of the polygon grows. I think, however, that this will be close enough for most uses. The math for a perfect calculation seems to be vastly more complicated. See [this](https://stackoverflow.com/questions/19897187/locating-the-centroid-center-of-mass-of-spherical-polygons) for example.