### PR TITLE
Typo in boundary

### DIFF
--- a/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
+++ b/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
@@ -171,7 +171,7 @@ module RGeo
           array << poly.exterior_ring unless poly.is_empty?
           array.concat(poly.interior_rings)
         end
-        factory.multilinestring(array)
+        factory.multi_line_string(array)
       end
 
       def coordinates

--- a/test/common/multi_polygon_tests.rb
+++ b/test/common/multi_polygon_tests.rb
@@ -190,6 +190,21 @@ module RGeo
         def test_point_on_surface
           assert_equal(@poly4.point_on_surface, @factory.point(7.5, 5.0))
         end
+
+        def test_boundary
+          parsed_geom = @factory.parse_wkt("MULTILINESTRING ((0.0 0.0, 0.0 -10.0, -10.0 0.0, 0.0 0.0), (0.0 0.0, 0.0 10.0, 10.0 10.0, 10.0 0.0, 0.0 0.0), (4.0 4.0, 5.0 6.0, 6.0 4.0, 4.0 4.0))")
+          built_geom = @factory.multi_polygon([@poly1, @poly2])
+          boundary_geom = built_geom.boundary
+          parsed_coordinates = parsed_geom.coordinates
+          boundary_coordinates = boundary_geom.coordinates
+          parsed_coordinates.zip(boundary_coordinates).each do |parsed_line, boundary_line|
+            parsed_line.zip(boundary_line).each do |p_coord, b_coord|
+              p_coord.zip(b_coord).each do |p_val, b_val|
+                assert_in_delta(p_val, b_val, 0.00000000000001)
+              end
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

When updating our gems after upgrading Ruby to 2.6, I noticed our specs failing in `lib/rgeo/impl_helper/basic_geometry_collection_methods.rb` for rgeo 2.1.1. The failure traced back to a change related to removing underscores from the impl_helper directory.

I did not find any issue related to this bug.

This pull request adds a test to reproduce the failure we noticed in our code as well as a fix to the affected method.