### PR TITLE
Change SphericalMath::PointXYZ to implement BigDecimal instead of Float

### DIFF
--- a/lib/rgeo/geographic/factory.rb
+++ b/lib/rgeo/geographic/factory.rb
@@ -43,6 +43,7 @@ module RGeo
           @coord_sys = CoordSys::CS.create_from_wkt(@coord_sys)
         end
         @lenient_assertions = opts[:uses_lenient_assertions] ? true : false
+        @uses_decimals = opts[:uses_decimals] ? true : false
         @buffer_resolution = opts[:buffer_resolution].to_i
         @buffer_resolution = 1 if @buffer_resolution < 1
 
@@ -107,6 +108,7 @@ module RGeo
           "wktp" => @wkt_parser.properties,
           "wkbp" => @wkb_parser.properties,
           "lena" => @lenient_assertions,
+          "decm" => @uses_decimals,
           "bufr" => @buffer_resolution
         }
         hash_["proj4"] = @proj4.marshal_dump if @proj4
@@ -139,6 +141,7 @@ module RGeo
           wkt_parser: symbolize_hash(data_["wktp"]),
           wkb_parser: symbolize_hash(data_["wkbp"]),
           uses_lenient_assertions: data_["lena"],
+          uses_decimals: data_["decm"],
           buffer_resolution: data_["bufr"],
           proj4: proj4,
           coord_sys: coord_sys
@@ -165,6 +168,7 @@ module RGeo
         coder["wkt_parser"] = @wkt_parser.properties
         coder["wkb_parser"] = @wkb_parser.properties
         coder["lenient_assertions"] = @lenient_assertions
+        coder["uses_decimals"] = @uses_decimals
         coder["buffer_resolution"] = @buffer_resolution
         if @proj4
           str = @proj4.original_str || @proj4.canonical_str
@@ -202,6 +206,7 @@ module RGeo
           wkt_parser: symbolize_hash(coder["wkt_parser"]),
           wkb_parser: symbolize_hash(coder["wkb_parser"]),
           uses_lenient_assertions: coder["lenient_assertions"],
+          uses_decimals: coder["uses_decimals"],
           buffer_resolution: coder["buffer_resolution"],
           proj4: proj4,
           coord_sys: coord_sys
@@ -295,6 +300,8 @@ module RGeo
           @support_m
         when :uses_lenient_assertions
           @lenient_assertions
+        when :uses_decimals
+          @uses_decimals
         when :buffer_resolution
           @buffer_resolution
         when :is_geographic

--- a/lib/rgeo/geographic/interface.rb
+++ b/lib/rgeo/geographic/interface.rb
@@ -60,6 +60,11 @@ module RGeo
       #   Polygon and MultiPolygon. This may speed up creation of certain
       #   objects, at the expense of not doing the proper checking for
       #   OGC compliance. Default is false.
+      # [<tt>:uses_decimals</tt>]
+      #   If set to true, spherical calculations will be performed using
+      #   BigDecimals instead of Floats. This creates more overhead,
+      #   but will mitigate floating-point rounding errors. Returned
+      #   features still use Floats to represent points. Default is false.
       # [<tt>:buffer_resolution</tt>]
       #   The resolution of buffers around geometries created by this
       #   factory. This controls the number of line segments used to
@@ -132,6 +137,7 @@ module RGeo
           proj4: proj4 || proj_4055,
           coord_sys: coord_sys || coord_sys_4055,
           uses_lenient_assertions: opts[:uses_lenient_assertions],
+          uses_decimals: opts[:uses_decimals],
           buffer_resolution: opts[:buffer_resolution],
           wkt_parser: opts[:wkt_parser],
           wkb_parser: opts[:wkb_parser],

--- a/lib/rgeo/geographic/spherical_feature_methods.rb
+++ b/lib/rgeo/geographic/spherical_feature_methods.rb
@@ -16,7 +16,7 @@ module RGeo
 
     module SphericalPointMethods # :nodoc:
       def xyz
-        @xyz ||= SphericalMath::PointXYZ.from_latlon(@y, @x)
+        @xyz ||= SphericalMath::PointXYZ.from_latlon(@y, @x, uses_decimals?)
       end
 
       def distance(rhs)
@@ -61,8 +61,8 @@ module RGeo
         angle = Math::PI * 2.0 / point_count
         points = (0...point_count).map do |i|
           r = angle * i
-          pi = SphericalMath::PointXYZ.weighted_combination(p1, Math.cos(r), p2, Math.sin(r))
-          p = SphericalMath::PointXYZ.weighted_combination(p0, cos, pi, sin)
+          pi = SphericalMath::PointXYZ.weighted_combination(p1, Math.cos(r), p2, Math.sin(r), uses_decimals?)
+          p = SphericalMath::PointXYZ.weighted_combination(p0, cos, pi, sin, uses_decimals?)
           factory.point(*p.lonlat)
         end
         factory.polygon(factory.linear_ring(points))
@@ -87,6 +87,10 @@ module RGeo
         @y = 90.0 if @y > 90.0
         @y = -90.0 if @y < -90.0
         super
+      end
+
+      def uses_decimals?
+        factory.property(:uses_decimals)
       end
     end
 

--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -31,7 +31,7 @@ module RGeo
           y = y.to_d
           z = z.to_d
 
-          r = Math.sqrt(x * x + y * y + z * z)
+          r = BigMath.sqrt(x * x + y * y + z * z, 15)
           @x = (x / r)
           @y = (y / r)
           @z = (z / r)
@@ -94,7 +94,7 @@ module RGeo
             x = @y * rz - @z * ry
             y = @z * rx - @x * rz
             z = @x * ry - @y * rx
-            as = Math.asin(Math.sqrt(x * x + y * y + z * z))
+            as = Math.asin(BigMath.sqrt(x * x + y * y + z * z, 15))
             dot > 0.0 ? as : Math::PI - as
           end
         end
@@ -116,10 +116,10 @@ module RGeo
           rpd = ImplHelper::Math::RADIANS_PER_DEGREE
           lat_rad = rpd * lat
           lon_rad = rpd * lon
-          z = Math.sin(lat_rad)
-          r = Math.cos(lat_rad)
-          x = Math.cos(lon_rad) * r
-          y = Math.sin(lon_rad) * r
+          z = BigMath.sin(lat_rad, 15)
+          r = BigMath.cos(lat_rad, 15)
+          x = BigMath.cos(lon_rad, 15) * r
+          y = BigMath.sin(lon_rad, 15) * r
           new(x, y, z)
         end
 

--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -7,7 +7,6 @@
 # -----------------------------------------------------------------------------
 require "bigdecimal"
 require "bigdecimal/util"
-require "bigdecimal/math"
 
 module RGeo
   module Geographic
@@ -31,7 +30,7 @@ module RGeo
           y = y.to_d
           z = z.to_d
 
-          r = BigMath.sqrt(x * x + y * y + z * z, 15)
+          r = Math.sqrt(x * x + y * y + z * z)
           @x = (x / r)
           @y = (y / r)
           @z = (z / r)
@@ -94,7 +93,7 @@ module RGeo
             x = @y * rz - @z * ry
             y = @z * rx - @x * rz
             z = @x * ry - @y * rx
-            as = Math.asin(BigMath.sqrt(x * x + y * y + z * z, 15))
+            as = Math.asin(Math.sqrt(x * x + y * y + z * z))
             dot > 0.0 ? as : Math::PI - as
           end
         end
@@ -116,10 +115,10 @@ module RGeo
           rpd = ImplHelper::Math::RADIANS_PER_DEGREE
           lat_rad = rpd * lat
           lon_rad = rpd * lon
-          z = BigMath.sin(lat_rad, 15)
-          r = BigMath.cos(lat_rad, 15)
-          x = BigMath.cos(lon_rad, 15) * r
-          y = BigMath.sin(lon_rad, 15) * r
+          z = Math.sin(lat_rad)
+          r = Math.cos(lat_rad)
+          x = Math.cos(lon_rad) * r
+          y = Math.sin(lon_rad) * r
           new(x, y, z)
         end
 

--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -25,10 +25,12 @@ module RGeo
       # of rotation.
 
       class PointXYZ # :nodoc:
-        def initialize(x, y, z)
-          x = x.to_d
-          y = y.to_d
-          z = z.to_d
+        def initialize(x, y, z, uses_decimals = false)
+          if uses_decimals
+            x = x.to_d
+            y = y.to_d
+            z = z.to_d
+          end
 
           r = Math.sqrt(x * x + y * y + z * z)
           @x = (x / r)
@@ -108,10 +110,7 @@ module RGeo
           p1dot < p2dot ? (self % P1) : (self % P2)
         end
 
-        def self.from_latlon(lat, lon)
-          lat = lat.to_d
-          lon = lon.to_d
-
+        def self.from_latlon(lat, lon, uses_decimals = false)
           rpd = ImplHelper::Math::RADIANS_PER_DEGREE
           lat_rad = rpd * lat
           lon_rad = rpd * lon
@@ -119,11 +118,11 @@ module RGeo
           r = Math.cos(lat_rad)
           x = Math.cos(lon_rad) * r
           y = Math.sin(lon_rad) * r
-          new(x, y, z)
+          new(x, y, z, uses_decimals)
         end
 
-        def self.weighted_combination(p1, w1, p2, w2)
-          new(p1.x * w1 + p2.x * w2, p1.y * w1 + p2.y * w2, p1.z * w1 + p2.z * w2)
+        def self.weighted_combination(p1, w1, p2, w2, uses_decimals = false)
+          new(p1.x * w1 + p2.x * w2, p1.y * w1 + p2.y * w2, p1.z * w1 + p2.z * w2, uses_decimals)
         end
 
         P1 = new(1, 0, 0)

--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -5,6 +5,9 @@
 # Core calculations on the sphere
 #
 # -----------------------------------------------------------------------------
+require "bigdecimal"
+require "bigdecimal/util"
+require "bigdecimal/math"
 
 module RGeo
   module Geographic
@@ -24,10 +27,14 @@ module RGeo
 
       class PointXYZ # :nodoc:
         def initialize(x, y, z)
+          x = x.to_d
+          y = y.to_d
+          z = z.to_d
+
           r = Math.sqrt(x * x + y * y + z * z)
-          @x = (x / r).to_f
-          @y = (y / r).to_f
-          @z = (z / r).to_f
+          @x = (x / r)
+          @y = (y / r)
+          @z = (z / r)
           raise "Not a number" if @x.nan? || @y.nan? || @z.nan?
         end
 
@@ -103,6 +110,9 @@ module RGeo
         end
 
         def self.from_latlon(lat, lon)
+          lat = lat.to_d
+          lon = lon.to_d
+
           rpd = ImplHelper::Math::RADIANS_PER_DEGREE
           lat_rad = rpd * lat
           lon_rad = rpd * lon

--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -5,7 +5,6 @@
 # Core calculations on the sphere
 #
 # -----------------------------------------------------------------------------
-require "bigdecimal"
 require "bigdecimal/util"
 
 module RGeo

--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -5,6 +5,7 @@
 # Core calculations on the sphere
 #
 # -----------------------------------------------------------------------------
+require "bigdecimal"
 require "bigdecimal/util"
 
 module RGeo

--- a/test/spherical_geographic/calculations_test.rb
+++ b/test/spherical_geographic/calculations_test.rb
@@ -161,10 +161,10 @@ class SphericalCalculationsTest < Minitest::Test # :nodoc:
   end
 
   def test_arc_intersects_decimal_precision
-    point1 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.58168793850955, 126.96804356077827)
-    point2 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.5816870915542, 126.96804348189114)
-    point3 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.58168238826706, 126.96804311029837)
-    point4 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.581642824769546, 126.96803990177084)
+    point1 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.58168793850955, 126.96804356077827, true)
+    point2 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.5816870915542, 126.96804348189114, true)
+    point3 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.58168238826706, 126.96804311029837, true)
+    point4 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.581642824769546, 126.96803990177084, true)
     arc1 = RGeo::Geographic::SphericalMath::ArcXYZ.new(point1, point2)
     arc2 = RGeo::Geographic::SphericalMath::ArcXYZ.new(point3, point4)
     assert_equal(false, arc1.intersects_arc?(arc2))

--- a/test/spherical_geographic/calculations_test.rb
+++ b/test/spherical_geographic/calculations_test.rb
@@ -159,4 +159,14 @@ class SphericalCalculationsTest < Minitest::Test # :nodoc:
     arc2 = RGeo::Geographic::SphericalMath::ArcXYZ.new(point3, point4)
     assert_equal(true, arc1.intersects_arc?(arc2))
   end
+
+  def test_arc_intersects_decimal_precision
+    point1 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.58168793850955, 126.96804356077827)
+    point2 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.5816870915542, 126.96804348189114)
+    point3 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.58168238826706, 126.96804311029837)
+    point4 = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(37.581642824769546, 126.96803990177084)
+    arc1 = RGeo::Geographic::SphericalMath::ArcXYZ.new(point1, point2)
+    arc2 = RGeo::Geographic::SphericalMath::ArcXYZ.new(point3, point4)
+    assert_equal(false, arc1.intersects_arc?(arc2))
+  end
 end

--- a/test/spherical_geographic/factory_test.rb
+++ b/test/spherical_geographic/factory_test.rb
@@ -16,5 +16,14 @@ class SphericalFactoryTest < Minitest::Test # :nodoc:
     @srid = 4055
   end
 
+  def test_uses_decimal
+    decm_factory = RGeo::Geographic.spherical_factory(uses_decimals: true)
+    assert_equal(true, decm_factory.property(:uses_decimals))
+
+    point = decm_factory.point(1, 0)
+    assert_equal(Float, point.x.class)
+    assert_equal(BigDecimal, point.xyz.x.class)
+  end
+
   undef_method :test_srid_preserved_through_geom_operations
 end

--- a/test/spherical_geographic/polygon_test.rb
+++ b/test/spherical_geographic/polygon_test.rb
@@ -26,6 +26,6 @@ class SphericalPolygonTest < Minitest::Test # :nodoc:
     point3 = @factory.point(1, 0)
     exterior = @factory.linear_ring([point1, point2, point3, point1])
     polygon = @factory.polygon(exterior)
-    assert_equal @factory.point(1.0/3.0, 1.0/3.0), polygon.centroid
+    assert_equal @factory.point(1.0 / 3.0, 1.0 / 3.0), polygon.centroid
   end
 end


### PR DESCRIPTION
### Summary

Resolves #212 

Valid polygons will sometimes fail the linear ring test in spherical factories if they have a high point density. The test erroneously detects that arcs of the polygon intersect causing it to fail the `is_simple?` condition. After some testing, I found out the issue has to do with floats lacking enough precision in the spherical coordinate system.

To fix this, I cast the floats to `BigDecimal`s before any calculations are done on them. This has so far worked for all of the cases I've found of the issue.

### Other Information

I attempted to integrate the `BigMath` library into the class to handle trigonometric and sqrt calculations but it made the tests take about 240x longer. I didn't notice any increase in accuracy by using it so removed it.
