### PR TITLE
Add a simple fallback for Polygon#contains?

### DIFF
--- a/lib/rgeo/impl_helper/basic_line_string_methods.rb
+++ b/lib/rgeo/impl_helper/basic_line_string_methods.rb
@@ -87,7 +87,44 @@ module RGeo
         @points.map(&:coordinates)
       end
 
+      def contains?(rhs)
+        if Feature::Point === rhs
+          return contains_point?(rhs)
+        else
+          raise(Error::UnsupportedOperation,
+            "Method LineString#contains? is only defined for Point"
+          )
+        end
+      end
+
+
       private
+
+      def contains_point?(point)
+        @points.each_cons(2) do |start_point, end_point|
+          return true if point_intersect_segment?(point, start_point, end_point)
+        end
+        false
+      end
+
+      def point_intersect_segment?(point, start_point, end_point)
+        return false unless point_collinear?(point, start_point, end_point)
+
+        if start_point.x != end_point.x
+          between_coordinate?(point.x, start_point.x, end_point.x)
+        else
+          between_coordinate?(point.y, start_point.y, end_point.y)
+        end
+      end
+
+      def point_collinear?(a, b, c)
+        (b.x - a.x) * (c.y - a.y) == (c.x - a.x) * (b.y - a.y)
+      end
+
+      def between_coordinate?(coord, start_coord, end_coord)
+        end_coord >= coord && coord >= start_coord ||
+          start_coord >= coord && coord >= end_coord
+      end
 
       def copy_state_from(obj)
         super

--- a/lib/rgeo/impl_helper/basic_polygon_methods.rb
+++ b/lib/rgeo/impl_helper/basic_polygon_methods.rb
@@ -79,7 +79,44 @@ module RGeo
         ([@exterior_ring] + @interior_rings).map(&:coordinates)
       end
 
+      def contains?(rhs)
+        if Feature::Point === rhs
+          contains_point?(rhs)
+        else
+          raise(Error::UnsupportedOperation,
+            "Method Polygon#contains? is only defined for Point"
+          )
+        end
+      end
+
       private
+
+      def contains_point?(point)
+        ring_encloses_point?(@exterior_ring, point) &&
+          !@interior_rings.any? do |exclusion|
+            ring_encloses_point?(exclusion, point, on_border_return: true)
+          end
+      end
+
+      def ring_encloses_point?(ring, point, on_border_return: false)
+        # This is an implementation of the ray casting algorithm, greatly inspired
+        # by https://wrf.ecse.rpi.edu/Research/Short_Notes/pnpoly.html
+        # Since this algorithm does not handle point on edge, we check first if
+        # the ring is on the border.
+        # on_border_return is used for exclusion ring
+        return on_border_return if ring.contains?(point)
+        encloses_point = false
+        ring.points.each_cons(2) do |start_point, end_point|
+          next unless (point.y < end_point.y) != (point.y < start_point.y)
+
+          if point.x < (end_point.x - start_point.x) * (point.y - start_point.y) /
+                       (end_point.y - start_point.y) + start_point.x
+            encloses_point = !encloses_point
+          end
+        end
+        encloses_point
+      end
+
 
       def copy_state_from(obj)
         super

--- a/test/common/line_string_tests.rb
+++ b/test/common/line_string_tests.rb
@@ -331,6 +331,16 @@ module RGeo
           line = @factory.line_string([point1, point2, point3])
           assert_equal(line.point_on_surface, point2)
         end
+
+        def test_contains_point
+          point1 = @factory.point(0, 0)
+          point2 = @factory.point(1, 2)
+          point3 = @factory.point(3, 9)
+          line_string = @factory.line_string([point1, point2, point3, point1])
+
+          assert_equal(true, line_string.contains?(@factory.point(0.5, 1)))
+          assert_equal(false, line_string.contains?(@factory.point(-1, -1)))
+        end
       end
     end
   end

--- a/test/common/polygon_tests.rb
+++ b/test/common/polygon_tests.rb
@@ -287,6 +287,50 @@ module RGeo
           polygon = @factory.polygon(exterior)
           assert_equal(polygon.point_on_surface, @factory.point(5.0, 5.0))
         end
+
+        def test_contains_point
+          point1 = @factory.point(0, 0)
+          point2 = @factory.point(0, 5)
+          point3 = @factory.point(5, 5)
+          point4 = @factory.point(5, 0)
+          exterior = @factory.linear_ring([point1, point2, point3, point4, point1])
+          polygon = @factory.polygon(exterior)
+
+          assert_equal(true, polygon.contains?(@factory.point(2.5, 2.5)))
+          assert_equal(false, polygon.contains?(@factory.point(6, 6)))
+          assert_equal(false, polygon.contains?(@factory.point(0, 2.5)))
+          assert_equal(false, polygon.contains?(@factory.point(2.5, 0)))
+          assert_equal(false, polygon.contains?(point1))
+          assert_equal(false, polygon.contains?(point2))
+          assert_equal(false, polygon.contains?(point3))
+          assert_equal(false, polygon.contains?(point4))
+        end
+
+        def test_contains_triangle
+          point1 = @factory.point(4, 4)
+          point2 = @factory.point(5, 6)
+          point3 = @factory.point(6, 4)
+          line_string = @factory.line_string([point1, point2, point3, point1])
+          polygon = @factory.polygon(line_string)
+          assert_equal(true, polygon.contains?(@factory.point(5, 5)))
+        end
+
+        def test_contains_point_one_hole
+          point1 = @factory.point(0, 0)
+          point2 = @factory.point(0, 10)
+          point3 = @factory.point(10, 10)
+          point4 = @factory.point(10, 0)
+          point5 = @factory.point(4, 4)
+          point6 = @factory.point(5, 6)
+          point7 = @factory.point(6, 4)
+          exterior = @factory.linear_ring([point1, point2, point3, point4, point1])
+          interior = @factory.linear_ring([point5, point6, point7, point5])
+          polygon = @factory.polygon(exterior, [interior])
+
+          assert_equal(true, polygon.contains?(@factory.point(2, 3)))
+          assert_equal(false, polygon.contains?(@factory.point(5, 5)))
+          assert_equal(false, polygon.contains?(@factory.point(4, 4)))
+        end
       end
     end
   end

--- a/test/simple_mercator/line_string_test.rb
+++ b/test/simple_mercator/line_string_test.rb
@@ -17,4 +17,5 @@ class MercatorLineStringTest < Minitest::Test # :nodoc:
 
   # These tests suffer from floating point issues
   undef_method :test_point_on_surface
+  undef_method :test_contains_point
 end


### PR DESCRIPTION
Implement default Polygon#contains? and LineString#contains? which handle a Point as input.

### Summary

Add a fallback on `Polygon and LineString contains` so that if `geos` is not available, rgeo can still be used to determine if a point is inside a polygon.
Its using a raycasting algorithm (https://wrf.ecse.rpi.edu/Research/Short_Notes/pnpoly.html) with a border check.

### Other Information

Hello rgeo!
At Klaxit, we are planning to migrate from our internal geometry library to rgeo.
Since we will use rgeo in some of our open source projects we dont want to add mandatory c dependencies.

Happy to iterate if some changes are needed.

thank you!