### PR TITLE
Standardize Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,67 @@
-dist: trusty
+language: ruby
+
+os:
+  - linux
+dist: xenial
+
 addons:
   apt:
     packages:
-      - libgeos-3.4.2
-language: ruby
+    - libgeos-dev
+    - libgeos-3.5.0
+
+jobs:
+  include:
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          packages:
+          - libgeos-dev
+          - libgeos-3.4.2
+
+    - os: linux
+      dist: xenial
+      addons:
+        apt:
+          packages:
+          - libgeos-dev
+          - libgeos-3.5.0
+
+    - os: linux
+      dist: bionic
+      addons:
+        apt:
+          packages:
+          - libgeos-dev
+          - libgeos-3.6.2
+
+    - os: linux
+      dist: eoan
+      addons:
+        apt:
+          packages:
+          - libgeos-dev
+          - libgeos-3.7.2
+
+    - os: linux
+      dist: focal
+      addons:
+        apt:
+          packages:
+          - libgeos-dev
+          - libgeos-3.8.0
+
+    - os: osx
+      addons:
+        homebrew:
+          packages:
+          - geos
+          update: true
+
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - 2.4
-  - jruby-9.2.6.0
+  - jruby-9.2.13.0

--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+### Current
+* Add SphericalPolygonMethods#centroid #208 (allknowingfrog)
+* Expand gemspec
+* Drop Ruby 2.3 support
+
 ### 2.1.1 / 2019-8-26
 
 * Fix BasicPolygonMethods#boundary #206 (ans82)

--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 * Add SphericalPolygonMethods#centroid #208 (allknowingfrog)
 * Expand gemspec
 * Drop Ruby 2.3 support
+* Change ProjectedLinearRing #is_simple? method to be uniform across geos versions #228
 
 ### 2.1.1 / 2019-8-26
 

--- a/History.md
+++ b/History.md
@@ -1,4 +1,5 @@
 ### Current
+
 * Add SphericalPolygonMethods#centroid #208 (allknowingfrog)
 * Expand gemspec
 * Drop Ruby 2.3 support

--- a/lib/rgeo/geographic/projected_feature_classes.rb
+++ b/lib/rgeo/geographic/projected_feature_classes.rb
@@ -33,6 +33,7 @@ module RGeo
       include ProjectedGeometryMethods
       include ProjectedNCurveMethods
       include ProjectedLineStringMethods
+      include ProjectedLinearRingMethods
     end
 
     class ProjectedLineImpl # :nodoc:

--- a/lib/rgeo/geographic/projected_feature_methods.rb
+++ b/lib/rgeo/geographic/projected_feature_methods.rb
@@ -166,6 +166,12 @@ module RGeo
       end
     end
 
+    module ProjectedLinearRingMethods # :nodoc:
+      def is_simple?
+        projection.valid?
+      end
+    end
+
     module ProjectedNSurfaceMethods # :nodoc:
       def area
         projection.area

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -121,6 +121,10 @@ module RGeo
         @fg_geom.simple?
       end
 
+      def valid?
+        @fg_geom.valid?
+      end
+
       def equals?(rhs)
         return false unless rhs.is_a?(RGeo::Feature::Instance)
         fg = factory.convert_to_fg_geometry(rhs)

--- a/test/common/multi_polygon_tests.rb
+++ b/test/common/multi_polygon_tests.rb
@@ -200,7 +200,7 @@ module RGeo
           parsed_coordinates.zip(boundary_coordinates).each do |parsed_line, boundary_line|
             parsed_line.zip(boundary_line).each do |p_coord, b_coord|
               p_coord.zip(b_coord).each do |p_val, b_val|
-                assert_in_delta(p_val, b_val, 0.00000000000001)
+                assert_in_delta(p_val, b_val, 1e-13)
               end
             end
           end

--- a/test/geos_capi/polygon_test.rb
+++ b/test/geos_capi/polygon_test.rb
@@ -11,6 +11,10 @@ require "test_helper"
 class GeosPolygonTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::PolygonTests
 
+  def assert_close_enough(p1, p2)
+    assert((p1.x - p2.x).abs < 0.00000001 && (p1.y - p2.y).abs < 0.00000001)
+  end
+
   def setup
     @factory = RGeo::Geos.factory
   end
@@ -109,7 +113,14 @@ class GeosPolygonTest < Minitest::Test # :nodoc:
     buffered_line_string =
       line_string.buffer_with_style(0.3, RGeo::Geos::CAP_SQUARE, RGeo::Geos::JOIN_MITRE, 5)
 
-    assert_equal polygon, buffered_line_string
+    # having issues with floating point errors on some systems
+    # 4.3 -> 4.29999999999999, for example, and throws an error
+    # iterating through points and using assert_in_delta instead
+    # of assert_equal
+    buffered_points = buffered_line_string.exterior_ring.points
+    polygon.exterior_ring.points.each_with_index do |pt, idx|
+      assert_close_enough(pt, buffered_points[idx])
+    end
   end
 
   def test_is_valid_polygon
@@ -143,5 +154,15 @@ class GeosPolygonTest < Minitest::Test # :nodoc:
     outer_ring = @factory.linear_ring(points_arr)
     polygon = @factory.polygon(outer_ring)
     polygon.invalid_reason
+  end
+
+  def test_self_intersecting_polygon
+    # issue 218
+    polygon_coordinates = [[0, 0], [1, 1], [0, 1], [1, 0], [0, 0]]
+    points_arr = polygon_coordinates.map{ |v| @factory.point(v[0], v[1]) }
+    outer_ring = @factory.linear_ring(points_arr)
+    polygon = @factory.polygon(outer_ring)
+
+    refute(polygon.is_simple?)
   end
 end if RGeo::Geos.capi_supported?

--- a/test/geos_ffi/polygon_test.rb
+++ b/test/geos_ffi/polygon_test.rb
@@ -36,4 +36,20 @@ class GeosFFIPolygonTest < Minitest::Test # :nodoc:
     poly3 = poly1.union(poly2)
     assert_equal(poly1, poly3)
   end
+
+  def test_is_valid_polygon
+    polygon_coordinates = [[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]]
+    points_arr = polygon_coordinates.map { |v| @factory.point(v[0], v[1]) }
+    outer_ring = @factory.linear_ring(points_arr)
+    polygon = @factory.polygon(outer_ring)
+
+    assert_equal(polygon.valid?, true)
+
+    polygon_coordinates = [[-1, -1], [-1, 0], [1, 0], [1, 1], [0, 1], [0, -1], [-1, -1]]
+    points_arr = polygon_coordinates.map { |v| @factory.point(v[0], v[1]) }
+    outer_ring = @factory.linear_ring(points_arr)
+    polygon = @factory.polygon(outer_ring)
+
+    assert_equal(polygon.valid?, false)
+  end
 end if RGeo::Geos.ffi_supported?

--- a/test/simple_mercator/polygon_test.rb
+++ b/test/simple_mercator/polygon_test.rb
@@ -15,6 +15,14 @@ class MercatorPolygonTest < Minitest::Test # :nodoc:
     @factory = RGeo::Geographic.simple_mercator_factory
   end
 
+  def test_is_simple_validation_behavior
+    # issue 218
+    assert_raises RGeo::Error::InvalidGeometry do
+      wkt = "POLYGON((0 0, 1 1, 1 0, 0 1, 0 0))"
+      RGeo::Geographic.simple_mercator_factory.parse_wkt(wkt)
+    end
+  end
+
   # These tests suffer from floating point issues
   undef_method :test_point_on_surface
   undef_method :test_boundary_one_hole

--- a/test/simple_mercator/polygon_test.rb
+++ b/test/simple_mercator/polygon_test.rb
@@ -19,7 +19,7 @@ class MercatorPolygonTest < Minitest::Test # :nodoc:
     # issue 218
     assert_raises RGeo::Error::InvalidGeometry do
       wkt = "POLYGON((0 0, 1 1, 1 0, 0 1, 0 0))"
-      RGeo::Geographic.simple_mercator_factory.parse_wkt(wkt)
+      @factory.parse_wkt(wkt)
     end
   end
 

--- a/test/simple_mercator/polygon_test.rb
+++ b/test/simple_mercator/polygon_test.rb
@@ -16,7 +16,7 @@ class MercatorPolygonTest < Minitest::Test # :nodoc:
   end
 
   def test_is_simple_validation_behavior
-    # issue 218
+    # See https://github.com/rgeo/rgeo/issues/218
     assert_raises RGeo::Error::InvalidGeometry do
       wkt = "POLYGON((0 0, 1 1, 1 0, 0 1, 0 0))"
       @factory.parse_wkt(wkt)


### PR DESCRIPTION
### Summary

PR to fix #218 where `is_simple?` returns inconsistent results across libgeos versions.

### Other Information

I personally tried using geos versions 3.5.2, 3.6.4, 3.7.3, and 3.8.1 across multiple Rubies and did not have a failing test case. I'm using Ubuntu Bionic so that may have something to do with it, but this is inconsistent with what is described in #218 .

I also looked at the libgeos docs and there is a note in there that suggests `GeosIsSimple` will always return `true` for polygons and that `GeosIsValid` would be the appropriate function to check for self-intersections. This is also described here https://postgis.net/docs/using_postgis_dbmanagement.html#OGC_Validity where it says "By definition, a POLYGON is always simple."