### PR TITLE
Add `MultiLineString#contains?` point fallback

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,9 +1,11 @@
 ### Current
+
 * Add SphericalPolygonMethods#centroid #208 (allknowingfrog)
 * Expand gemspec
 * Drop Ruby 2.3 support
 * Add a simple fallback for `Polygon#contains?` (Quiwin) #224
 * Add `ccw?` method for linear rings, with geos support #229
+* Add a simple fallback for `MultiPolygon/LineString#contains?` (Quiwin) #230/231
 
 ### 2.1.1 / 2019-8-26
 

--- a/History.md
+++ b/History.md
@@ -5,7 +5,7 @@
 * Drop Ruby 2.3 support
 * Add a simple fallback for `Polygon#contains?` (Quiwin) #224
 * Add `ccw?` method for linear rings, with geos support #229
-* Add a simple fallback for `MultiPolygon/LineString#contains?` (Quiwin) #230/231
+* Add a simple fallback for `MultiPolygon/LineString#contains?` (Quiwin) #230 #232
 
 ### 2.1.1 / 2019-8-26
 

--- a/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
+++ b/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
@@ -114,6 +114,12 @@ module RGeo
         @elements.map(&:coordinates)
       end
 
+      def contains?(rhs)
+        return super unless Feature::Point === rhs
+
+        @elements.any? { |line| line.contains?(rhs) }
+      end
+
       private
 
       def add_boundary(hash, point)

--- a/test/common/multi_line_string_tests.rb
+++ b/test/common/multi_line_string_tests.rb
@@ -178,6 +178,12 @@ module RGeo
           ml = @factory.multi_line_string([@linestring1, @linestring2])
           assert_equal(ml.point_on_surface, @factory.point(-7, 6))
         end
+
+        def test_contains_point
+          ml = @factory.multi_line_string([@linestring1, @linestring2])
+          pt = @factory.point(-7, 6) # point4
+          assert_equal(true, ml.contains?(pt))
+        end
       end
     end
   end

--- a/test/simple_cartesian/multi_line_string_test.rb
+++ b/test/simple_cartesian/multi_line_string_test.rb
@@ -15,6 +15,15 @@ class CartesianMultiLineStringTest < Minitest::Test # :nodoc:
     @factory = RGeo::Cartesian.simple_factory
   end
 
+  def test_contains_not_point
+    ml1 = @factory.multi_line_string([])
+    ml2 = @factory.multi_line_string([])
+
+    assert_raises(RGeo::Error::UnsupportedOperation) do
+      ml1.contains?(ml2)
+    end
+  end
+
   undef_method :test_fully_equal
   undef_method :test_geometrically_equal
   undef_method :test_not_equal


### PR DESCRIPTION
### Summary

Adds the `contains?` method for `MutliLineString` cartesian and spherical implementations.
