### PR TITLE
Improve geos multipolygon creation performance

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 ### Current
 
 * Change ProjectedLinearRing #is_simple? method to be uniform across geos versions #228
+* Improve large MultiPolygon creation performance (Quiwin) #251
 
 ### 2.2.0 / 2020-11-18
 

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -41,9 +41,6 @@ static VALUE create_geometry_collection(VALUE module, int type, VALUE factory, V
   VALUE cast_type;
   GEOSGeometry* geom;
   GEOSGeometry* collection;
-  char problem;
-  GEOSGeometry* igeom;
-  GEOSGeometry* jgeom;
 
   result = Qnil;
   Check_Type(array, T_ARRAY);

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -89,10 +89,10 @@ static VALUE create_geometry_collection(VALUE module, int type, VALUE factory, V
     else {
       collection = GEOSGeom_createCollection_r(geos_context, type, geoms, len);
       // Check if MultiPolygon is valid.
-      if (collection &&
-          type == GEOS_MULTIPOLYGON
-          && (factory_data->flags & 1) == 0
-          && (GEOSisValid_r(geos_context, collection) == 0)) {
+      if (collection
+          && type == GEOS_MULTIPOLYGON
+          && !(factory_data->flags & 1)
+          && !GEOSisValid_r(geos_context, collection)) {
         GEOSGeom_destroy_r(geos_context, collection);
         collection = NULL;
       }

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -88,31 +88,13 @@ static VALUE create_geometry_collection(VALUE module, int type, VALUE factory, V
     }
     else {
       collection = GEOSGeom_createCollection_r(geos_context, type, geoms, len);
-      // Due to a limitation of GEOS, the MultiPolygon assertions are not checked.
-      // We do that manually here.
-      if (collection && type == GEOS_MULTIPOLYGON && (factory_data->flags & 1) == 0) {
-        problem = 0;
-        for (i=1; i<len; ++i) {
-          for (j=0; j<i; ++j) {
-            igeom = geoms[i];
-            jgeom = geoms[j];
-            problem = GEOSRelatePattern_r(geos_context, igeom, jgeom, "2********");
-            if (problem) {
-              break;
-            }
-            problem = GEOSRelatePattern_r(geos_context, igeom, jgeom, "****1****");
-            if (problem) {
-              break;
-            }
-          }
-          if (problem) {
-            break;
-          }
-        }
-        if (problem) {
-          GEOSGeom_destroy_r(geos_context, collection);
-          collection = NULL;
-        }
+      // Check if MultiPolygon is valid.
+      if (collection &&
+          type == GEOS_MULTIPOLYGON
+          && (factory_data->flags & 1) == 0
+          && (GEOSisValid_r(geos_context, collection) == 0)) {
+        GEOSGeom_destroy_r(geos_context, collection);
+        collection = NULL;
       }
       if (collection) {
         result = rgeo_wrap_geos_geometry(factory, collection, module);


### PR DESCRIPTION
Replace a manual validity check on MultiPolygon, which was iterating on
each polygon combination, by a direct call of geos isValid.

### Summary
Hello !

MultiPolygon creation was slower than expected on large [MultiPolygon](https://gist.github.com/Quiwin/d3b0f47d5669260fd46d8ea3ad47077a), it was due to an old check for validity which manually iterated on every polygon combination of the given multiPolygon.
Now directly call geos to check for validity.

### Other Information
Tested with above geojson:
```ruby
geojson = IO.read("france.geojson")
require 'micro_bench'
MicroBench.start;RGeo::GeoJSON.decode(geojson, geo_factory: RGeo::Cartesian.preferred_factory); puts "#{MicroBench.duration.round(2)} sec"
```
Before: 1.95 sec
After: 0.35 sec


I couldn't find the [exact geos issue](https://trac.osgeo.org/geos/search?milestone=on&changeset=on&ticket=on&wiki=on&q=multipolygon+valid&page=3&noquickjump=1) it tried to avoid
but I dont think there is much risk since the previous code written to circumvent it was more than 11 years ago https://github.com/rgeo/rgeo/commit/c44767eec656d9780919d007de41be8f19f773bc

Thanks!
