### PR TITLE
Fix `Polygon#invalid_reason`

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+* Fix a memory leak in CAPI's `#invalid_reason`
+* `#invalid_reason` now must return `nil` if polygon is valid.
+
 ### 2.2.0 / 2020-11-18
 
 * Add SphericalPolygonMethods#centroid #208 (allknowingfrog)

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -1045,12 +1045,13 @@ static VALUE method_geometry_invalid_reason(VALUE self)
   self_geom = self_data->geom;
   if (self_geom) {
     str = GEOSisValidReason_r(self_data->geos_context, self_geom);
-    if (str) {
-      result = rb_str_new2(str);
-    }
-    else {
-      result = rb_str_new2("Exception");
-    }
+    // Per documentation, a valid geometry should give an empty string.
+    // However it seems not to be the case. Hence the comparison against
+    // the string that is really given: `"Valid Geometry"`.
+    // See https://github.com/libgeos/geos/issues/431.
+    if (str) result = (str[0] == '\0' || !strcmp(str, "Valid Geometry")) ? Qnil : rb_str_new2(str);
+    else result = rb_str_new2("Exception");
+    GEOSFree_r(self_data->geos_context, str);
   }
   return result;
 }

--- a/test/geos_capi/polygon_test.rb
+++ b/test/geos_capi/polygon_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "../test_helper"
 
 class GeosPolygonTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::PolygonTests
@@ -134,7 +134,7 @@ class GeosPolygonTest < Minitest::Test # :nodoc:
     outer_ring = @factory.linear_ring(points_arr)
     polygon = @factory.polygon(outer_ring)
 
-    assert_equal(polygon.invalid_reason, "Self-intersection[0 0 0]")
+    assert_equal("Self-intersection[0 0 0]", polygon.invalid_reason)
   end
 
   def test_invalid_reason_with_valid_polygon
@@ -142,6 +142,6 @@ class GeosPolygonTest < Minitest::Test # :nodoc:
     points_arr = polygon_coordinates.map{ |v| @factory.point(v[0], v[1]) }
     outer_ring = @factory.linear_ring(points_arr)
     polygon = @factory.polygon(outer_ring)
-    polygon.invalid_reason
+    assert_equal(nil, polygon.invalid_reason)
   end
 end if RGeo::Geos.capi_supported?


### PR DESCRIPTION
Fixes both the returned value, which should be `Qnil` under some
circumstances, and the related memory leak, pointer was not correctly
freed.

REPRO:

```ruby
#!/usr/bin/env ruby -I. -r./lib/rgeo.rb
require "get_process_mem"

pt = RGeo::Geos.factory.point(1,0)
rep = 10_000_000

10.times do
  rep.times { pt.invalid_reason }
  GC.start
  puts GetProcessMem.new.mb
end
```

@keithdoggett I'd like to rebase the v3-dev branch after merge if that is ok with you