### PR TITLE
Use native `GEOSEqualsExact_r` comparison

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,8 @@ jobs:
           - ubuntu
           - windows
           - macos
+        exclude:
+          - os: windows # See issue #242, windows support would be welcome.
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ matrix.ruby == 'head' || matrix.os == 'windows' || matrix.os == 'macos' }}
     name: Ruby ${{ matrix.ruby }} (${{ matrix.os }})

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * Change ProjectedLinearRing #is_simple? method to be uniform across geos versions #228
 * Improve large MultiPolygon creation performance (Quiwin) #251
+* Fix CAPI equality (`==`) comparison on macos by using `GEOSEqualsExact_r` #270
 
 ### 2.3.0 / 2021-04-16
 

--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -198,15 +198,6 @@ void rgeo_check_geos_object(VALUE obj);
 const GEOSGeometry* rgeo_get_geos_geometry_safe(VALUE obj);
 
 /*
-  Compares the coordinate sequences for two given GEOS geometries.
-  The two given geometries MUST be of types backed directly by
-  coordinate sequences-- i.e. points or line strings.
-  Returns Qtrue if the two coordinate sequences are equal, Qfalse
-  if they are inequal, or Qnil if an error occurs.
-*/
-VALUE rgeo_geos_coordseqs_eql(GEOSContextHandle_t context, const GEOSGeometry* geom1, const GEOSGeometry* geom2, char check_z);
-
-/*
   Compares the ruby classes and geometry factories of the two given ruby
   objects. Returns Qtrue if everything is equal (that is, the two objects
   are of the same type and factory), or Qfalse otherwise.

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -11,6 +11,7 @@
 #include <ruby.h>
 #include <geos_c.h>
 
+#include "errors.h"
 #include "factory.h"
 #include "geometry.h"
 
@@ -863,24 +864,21 @@ static VALUE method_geometry_union(VALUE self, VALUE rhs)
 
 static VALUE method_geometry_unary_union(VALUE self)
 {
-  VALUE result;
+#ifdef RGEO_GEOS_SUPPORTS_UNARYUNION
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
 
-  result = Qnil;
-
-#ifdef RGEO_GEOS_SUPPORTS_UNARYUNION
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
     GEOSContextHandle_t self_context = self_data->geos_context;
-    result = rgeo_wrap_geos_geometry(self_data->factory,
+    return rgeo_wrap_geos_geometry(self_data->factory,
       GEOSUnaryUnion_r(self_context, self_geom),
       Qnil);
   }
 #endif
 
-  return result;
+  return Qnil;
 }
 
 
@@ -1071,6 +1069,18 @@ static VALUE method_geometry_point_on_surface(VALUE self)
   return result;
 }
 
+VALUE rgeo_geos_geometries_strict_eql(GEOSContextHandle_t context, const GEOSGeometry* geom1, const GEOSGeometry* geom2)
+{
+  switch (GEOSEqualsExact_r(context, geom1, geom2, 0.0)) {
+  case 0:
+    return Qfalse;
+  case 1:
+    return Qtrue;
+  case 2:
+  default:
+    rb_raise(geos_error, "Cannot test equality.");
+  }
+}
 
 /**** INITIALIZATION FUNCTION ****/
 

--- a/ext/geos_c_impl/geometry.h
+++ b/ext/geos_c_impl/geometry.h
@@ -18,6 +18,13 @@ RGEO_BEGIN_C
 void rgeo_init_geos_geometry(RGeo_Globals* globals);
 
 
+/*
+  Compares two geometries using strict GEOS comparison. return Qtrue
+  if they are equal, Qfalse otherwise.
+  May raise a `RGeo::Error::GeosError`.
+*/
+VALUE rgeo_geos_geometries_strict_eql(GEOSContextHandle_t context, const GEOSGeometry* geom1, const GEOSGeometry* geom2);
+
 RGEO_END_C
 
 #endif

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -14,6 +14,7 @@
 #include "geometry.h"
 #include "line_string.h"
 #include "polygon.h"
+#include "geometry.h"
 #include "geometry_collection.h"
 
 #include "coordinates.h"
@@ -120,7 +121,7 @@ static VALUE method_geometry_collection_eql(VALUE self, VALUE rhs)
   result = rgeo_geos_klasses_and_factories_eql(self, rhs);
   if (RTEST(result)) {
     self_data = RGEO_GEOMETRY_DATA_PTR(self);
-    result = rgeo_geos_geometry_collections_eql(self_data->geos_context, self_data->geom, RGEO_GEOMETRY_DATA_PTR(rhs)->geom, RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M);
+    result = rgeo_geos_geometries_strict_eql(self_data->geos_context, self_data->geom, RGEO_GEOMETRY_DATA_PTR(rhs)->geom);
   }
   return result;
 }
@@ -617,80 +618,6 @@ void rgeo_init_geos_geometry_collection(RGeo_Globals* globals)
 
 
 /**** OTHER PUBLIC FUNCTIONS ****/
-
-
-VALUE rgeo_geos_geometry_collections_eql(GEOSContextHandle_t context, const GEOSGeometry* geom1, const GEOSGeometry* geom2, char check_z)
-{
-  VALUE result;
-  int len1;
-  int len2;
-  int i;
-  const GEOSGeometry* sub_geom1;
-  const GEOSGeometry* sub_geom2;
-  int type1;
-  int type2;
-
-  result = Qnil;
-  if (geom1 && geom2) {
-    len1 = GEOSGetNumGeometries_r(context, geom1);
-    len2 = GEOSGetNumGeometries_r(context, geom2);
-    if (len1 >= 0 && len2 >= 0) {
-      if (len1 == len2) {
-        result = Qtrue;
-        for (i=0; i<len1; ++i) {
-          sub_geom1 = GEOSGetGeometryN_r(context, geom1, i);
-          sub_geom2 = GEOSGetGeometryN_r(context, geom2, i);
-          if (sub_geom1 && sub_geom2) {
-            type1 = GEOSGeomTypeId_r(context, sub_geom1);
-            type2 = GEOSGeomTypeId_r(context, sub_geom2);
-            if (type1 >= 0 && type2 >= 0) {
-              if (type1 == type2) {
-                switch (type1) {
-                case GEOS_POINT:
-                case GEOS_LINESTRING:
-                case GEOS_LINEARRING:
-                  result = rgeo_geos_coordseqs_eql(context, sub_geom1, sub_geom2, check_z);
-                  break;
-                case GEOS_POLYGON:
-                  result = rgeo_geos_polygons_eql(context, sub_geom1, sub_geom2, check_z);
-                  break;
-                case GEOS_GEOMETRYCOLLECTION:
-                case GEOS_MULTIPOINT:
-                case GEOS_MULTILINESTRING:
-                case GEOS_MULTIPOLYGON:
-                  result = rgeo_geos_geometry_collections_eql(context, sub_geom1, sub_geom2, check_z);
-                  break;
-                default:
-                  result = Qnil;
-                  break;
-                }
-                if (!RTEST(result)) {
-                  break;
-                }
-              }
-              else {
-                result = Qfalse;
-                break;
-              }
-            }
-            else {
-              result = Qnil;
-              break;
-            }
-          }
-          else {
-            result = Qnil;
-            break;
-          }
-        }
-      }
-      else {
-        result = Qfalse;
-      }
-    }
-  }
-  return result;
-}
 
 
 st_index_t rgeo_geos_geometry_collection_hash(GEOSContextHandle_t context, const GEOSGeometry* geom, st_index_t hash)

--- a/ext/geos_c_impl/geometry_collection.h
+++ b/ext/geos_c_impl/geometry_collection.h
@@ -21,17 +21,6 @@ RGEO_BEGIN_C
 void rgeo_init_geos_geometry_collection(RGeo_Globals* globals);
 
 /*
-  Comopares the contents of two geometry collections. Does not test the
-  types of the collections themselves, but tests the types, values, and
-  contents of all the contents. The two given geometries MUST be
-  collection types-- i.e. GeometryCollection, MultiPoint, MultiLineString,
-  or MultiPolygon.
-  Returns Qtrue if the contents of the two geometry collections are equal,
-  Qfalse if they are inequal, or Qnil if an error occurs.
-*/
-VALUE rgeo_geos_geometry_collections_eql(GEOSContextHandle_t context, const GEOSGeometry* geom1, const GEOSGeometry* geom2, char check_z);
-
-/*
   A tool for building up hash values.
   You must pass in the context, a geos geometry, and a seed hash.
   Returns an updated hash.

--- a/ext/geos_c_impl/line_string.c
+++ b/ext/geos_c_impl/line_string.c
@@ -343,7 +343,7 @@ static VALUE method_line_string_eql(VALUE self, VALUE rhs)
   result = rgeo_geos_klasses_and_factories_eql(self, rhs);
   if (RTEST(result)) {
     self_data = RGEO_GEOMETRY_DATA_PTR(self);
-    result = rgeo_geos_coordseqs_eql(self_data->geos_context, self_data->geom, RGEO_GEOMETRY_DATA_PTR(rhs)->geom, RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M);
+    result = rgeo_geos_geometries_strict_eql(self_data->geos_context, self_data->geom, RGEO_GEOMETRY_DATA_PTR(rhs)->geom);
   }
   return result;
 }

--- a/ext/geos_c_impl/point.c
+++ b/ext/geos_c_impl/point.c
@@ -153,7 +153,7 @@ static VALUE method_point_eql(VALUE self, VALUE rhs)
   result = rgeo_geos_klasses_and_factories_eql(self, rhs);
   if (RTEST(result)) {
     self_data = RGEO_GEOMETRY_DATA_PTR(self);
-    result = rgeo_geos_coordseqs_eql(self_data->geos_context, self_data->geom, RGEO_GEOMETRY_DATA_PTR(rhs)->geom, RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M);
+    result = rgeo_geos_geometries_strict_eql(self_data->geos_context, self_data->geom, RGEO_GEOMETRY_DATA_PTR(rhs)->geom);
   }
   return result;
 }

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -28,7 +28,7 @@ static VALUE method_polygon_eql(VALUE self, VALUE rhs)
   result = rgeo_geos_klasses_and_factories_eql(self, rhs);
   if (RTEST(result)) {
     self_data = RGEO_GEOMETRY_DATA_PTR(self);
-    result = rgeo_geos_polygons_eql(self_data->geos_context, self_data->geom, RGEO_GEOMETRY_DATA_PTR(rhs)->geom, RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M);
+    result = rgeo_geos_geometries_strict_eql(self_data->geos_context, self_data->geom, RGEO_GEOMETRY_DATA_PTR(rhs)->geom);
   }
   return result;
 }
@@ -298,42 +298,6 @@ void rgeo_init_geos_polygon(RGeo_Globals* globals)
   rb_define_method(geos_polygon_methods, "interior_rings", method_polygon_interior_rings, 0);
   rb_define_method(geos_polygon_methods, "coordinates", method_polygon_coordinates, 0);
 }
-
-
-VALUE rgeo_geos_polygons_eql(GEOSContextHandle_t context, const GEOSGeometry* geom1, const GEOSGeometry* geom2, char check_z)
-{
-  VALUE result;
-  int len1;
-  int len2;
-  int i;
-
-  result = Qnil;
-  if (geom1 && geom2) {
-    result = rgeo_geos_coordseqs_eql(context, GEOSGetExteriorRing_r(context, geom1), GEOSGetExteriorRing_r(context, geom2), check_z);
-    if (RTEST(result)) {
-      len1 = GEOSGetNumInteriorRings_r(context, geom1);
-      len2 = GEOSGetNumInteriorRings_r(context, geom2);
-      if (len1 >= 0 && len2 >= 0) {
-        if (len1 == len2) {
-          for (i=0; i<len1; ++i) {
-            result = rgeo_geos_coordseqs_eql(context, GEOSGetInteriorRingN_r(context, geom1, i), GEOSGetInteriorRingN_r(context, geom2, i), check_z);
-            if (!RTEST(result)) {
-              break;
-            }
-          }
-        }
-        else {
-          result = Qfalse;
-        }
-      }
-      else {
-        result = Qnil;
-      }
-    }
-  }
-  return result;
-}
-
 
 st_index_t rgeo_geos_polygon_hash(GEOSContextHandle_t context, const GEOSGeometry* geom, st_index_t hash)
 {

--- a/test/common/factory_tests.rb
+++ b/test/common/factory_tests.rb
@@ -64,7 +64,7 @@ module RGeo
 
         def test_psych_dump_load_factory
           data = Psych.dump(@factory)
-          factory2 = Psych.load(data)
+          factory2 = psych_load(data)
           assert_equal(@factory, factory2)
           assert_equal(srid, factory2.srid)
         end

--- a/test/common/line_string_tests.rb
+++ b/test/common/line_string_tests.rb
@@ -320,7 +320,7 @@ module RGeo
           point2 = @factory.point(0, 1)
           line1 = @factory.line_string([point1, point2])
           data = Psych.dump(line1)
-          line2 = Psych.load(data)
+          line2 = psych_load(data)
           assert_equal(line1, line2)
         end
 

--- a/test/common/point_tests.rb
+++ b/test/common/point_tests.rb
@@ -341,21 +341,21 @@ module RGeo
         def test_psych_roundtrip
           point = @factory.point(11, 12)
           data = Psych.dump(point)
-          point2 = Psych.load(data)
+          point2 = psych_load(data)
           assert_equal(point, point2)
         end
 
         def test_psych_roundtrip_3d
           point = @zfactory.point(11, 12, 13)
           data = Psych.dump(point)
-          point2 = Psych.load(data)
+          point2 = psych_load(data)
           assert_equal(point, point2)
         end
 
         def test_psych_roundtrip_4d
           point = @zmfactory.point(11, 12, 13, 14)
           data = Psych.dump(point)
-          point2 = Psych.load(data)
+          point2 = psych_load(data)
           assert_equal(point, point2)
         end
 

--- a/test/common/polygon_tests.rb
+++ b/test/common/polygon_tests.rb
@@ -83,7 +83,9 @@ module RGeo
           exterior2 = @factory.linear_ring([point2, point3, point1, point2])
           poly2 = @factory.polygon(exterior2)
           assert(!poly1.rep_equals?(poly2))
+          assert(!poly1.eql?(poly2))
           assert(poly1.equals?(poly2))
+          assert(poly1 == poly2)
         end
 
         def test_geometrically_equal_but_different_directions
@@ -95,7 +97,9 @@ module RGeo
           exterior2 = @factory.linear_ring([point1, point3, point2, point1])
           poly2 = @factory.polygon(exterior2)
           assert(!poly1.rep_equals?(poly2))
+          assert(!poly1.eql?(poly2))
           assert(poly1.equals?(poly2))
+          assert(poly1 == poly2)
         end
 
         def test_hashes_equal_for_representationally_equivalent_objects

--- a/test/coord_sys/ogc_cs_test.rb
+++ b/test/coord_sys/ogc_cs_test.rb
@@ -327,7 +327,7 @@ class OgcCsTest < Minitest::Test # :nodoc:
     input = 'COMPD_CS["OSGB36 / British National Grid + ODN",PROJCS["OSGB 1936 / British National Grid",GEOGCS["OSGB 1936",DATUM["OSGB 1936",SPHEROID["Airy 1830",6377563.396,299.3249646,AUTHORITY["EPSG","7001"]],TOWGS84[446.448,-125.157,542.06,0.15,0.247,0.842,-4.2261596151967575],AUTHORITY["EPSG","6277"]],PRIMEM["Greenwich",0.0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.017453292519943295],AXIS["Geodetic latitude",NORTH],AXIS["Geodetic longitude",EAST],AUTHORITY["EPSG","4277"]],PROJECTION["Transverse Mercator",AUTHORITY["EPSG","9807"]],PARAMETER["central_meridian",-2.0],PARAMETER["latitude_of_origin",49.0],PARAMETER["scale_factor",0.9996012717],PARAMETER["false_easting",400000.0],PARAMETER["false_northing",-100000.0],UNIT["m",1.0],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","27700"]],VERT_CS["Newlyn",VERT_DATUM["Ordnance Datum Newlyn",2005,AUTHORITY["EPSG","5101"]],UNIT["m",1.0],AXIS["Gravity-related height",UP],AUTHORITY["EPSG","5701"]],AUTHORITY["EPSG","7405"]]'
     obj1 = RGeo::CoordSys::CS.create_from_wkt(input)
     dump = Psych.dump(obj1)
-    obj2 = Psych.load(dump)
+    obj2 = psych_load(dump)
     assert_equal(obj1, obj2)
   end
 end

--- a/test/geos_capi/misc_test.rb
+++ b/test/geos_capi/misc_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "../test_helper"
 
 class GeosMiscTest < Minitest::Test # :nodoc:
   def setup
@@ -132,7 +132,8 @@ class GeosMiscTest < Minitest::Test # :nodoc:
     expected = @factory.parse_wkt("GEOMETRYCOLLECTION (POINT (60 140),   LINESTRING (40 90, 40 140), LINESTRING (160 90, 160 140), POLYGON ((0 0, 0 90, 40 90, 90 90, 90 0, 0 0)), POLYGON ((120 0, 120 90, 160 90, 210 90, 210 0, 120 0)))")
     geom = collection.unary_union
     if RGeo::Geos::CAPIFactory._supports_unary_union?
-      assert(geom.eql?(expected))
+      # Note that here `.eql?` is not guaranteed on all GEOS implementation.
+      assert(geom == expected)
     else
       assert_equal(nil, geom)
     end

--- a/test/geos_ffi/misc_test.rb
+++ b/test/geos_ffi/misc_test.rb
@@ -70,7 +70,8 @@ class GeosFFIMiscTest < Minitest::Test # :nodoc:
     expected = @factory.parse_wkt("GEOMETRYCOLLECTION (POINT (60 140),   LINESTRING (40 90, 40 140), LINESTRING (160 90, 160 140), POLYGON ((0 0, 0 90, 40 90, 90 90, 90 0, 0 0)), POLYGON ((120 0, 120 90, 160 90, 210 90, 210 0, 120 0)))")
     geom = collection.unary_union
     if RGeo::Geos::Utils.ffi_supports_unary_union
-      assert(geom.eql?(expected))
+      # Representation may differ, hence the test with `==` rather than `eql?`
+      assert(geom == expected)
     else
       assert_equal(nil, geom)
     end

--- a/test/simple_cartesian/point_test.rb
+++ b/test/simple_cartesian/point_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "../test_helper"
 
 class CartesianPointTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::PointTests

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,17 @@
 require "minitest/autorun"
 require_relative "../lib/rgeo"
 require "psych"
+
+# Only here for Psych 4.0.0 breaking change.
+# See https://github.com/ruby/psych/pull/487
+def psych_load(*args)
+  if Psych.respond_to?(:unsafe_load)
+    Psych.unsafe_load(*args)
+  else
+    Psych.load(*args)
+  end
+end
+
 require_relative "common/factory_tests"
 require_relative "common/geometry_collection_tests"
 require_relative "common/line_string_tests"


### PR DESCRIPTION
### Summary

This make for less C code on our part, and allowed to fix a MacOS
related bug.


### Other Information

At first I went with the `rgeo_geos_geometries_norm_eql` implementation, which allows to test for equality even if geometries are not in correct order. However, according to our documentation (https://github.com/rgeo/rgeo/blob/master/doc/An-Introduction-to-Spatial-Programming-With-RGeo.md#32-relational-operations), it seems that we should really use the `rgeo_geos_geometries_strict_eql` version, and just change the tests to use correct comparison. IMHO, it is ok to have possibly different representation when doing an unary union.

I won't keep both implementation when merging, I've just let those for review reasons!
