### PR TITLE
fix: lenient_assertion flags for simple_mercator_factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ mkmf.log
 Gemfile.lock
 /yardoc
 /.yardoc
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ mkmf.log
 Gemfile.lock
 /yardoc
 /.yardoc
+.idea

--- a/lib/rgeo/geographic/interface.rb
+++ b/lib/rgeo/geographic/interface.rb
@@ -222,7 +222,8 @@ module RGeo
           wkt_generator: opts[:wkt_generator],
           wkb_generator: opts[:wkb_generator],
           has_z_coordinate: opts[:has_z_coordinate],
-          has_m_coordinate: opts[:has_m_coordinate])
+          has_m_coordinate: opts[:has_m_coordinate],
+          uses_lenient_assertions: opts[:uses_lenient_assertions])
         projector = Geographic::SimpleMercatorProjector.new(factory,
           buffer_resolution: opts[:buffer_resolution],
           lenient_multi_polygon_assertions: opts[:lenient_multi_polygon_assertions],

--- a/test/simple_mercator/factory_test.rb
+++ b/test/simple_mercator/factory_test.rb
@@ -15,4 +15,10 @@ class MercatorFactoryTest < Minitest::Test # :nodoc:
     @factory = RGeo::Geographic.simple_mercator_factory
     @srid = 4326
   end
+
+  def test_has_uses_lenient_assertions
+    factory = RGeo::Geographic.simple_mercator_factory(uses_lenient_assertions: true)
+
+    assert_equal(true, factory.property(:uses_lenient_assertions))
+  end
 end

--- a/test/simple_mercator/factory_test.rb
+++ b/test/simple_mercator/factory_test.rb
@@ -23,14 +23,14 @@ class MercatorFactoryTest < Minitest::Test # :nodoc:
   end
 
   def test_ring_has_lenient_assertions
-    ring = -> (factory) {
+    ring = lambda do |factory|
       factory.linear_ring([
-        factory.point(0, 0),
-        factory.point(1, 1),
-        factory.point(0, 1),
-        factory.point(1, 0)
-      ])
-    }
+                            factory.point(0, 0),
+                            factory.point(1, 1),
+                            factory.point(0, 1),
+                            factory.point(1, 0)
+                          ])
+    end
 
     assert_raises { ring.call RGeo::Geographic.simple_mercator_factory }
 

--- a/test/simple_mercator/factory_test.rb
+++ b/test/simple_mercator/factory_test.rb
@@ -21,4 +21,19 @@ class MercatorFactoryTest < Minitest::Test # :nodoc:
 
     assert_equal(true, factory.property(:uses_lenient_assertions))
   end
+
+  def test_ring_has_lenient_assertions
+    ring = -> (factory) {
+      factory.linear_ring([
+        factory.point(0, 0),
+        factory.point(1, 1),
+        factory.point(0, 1),
+        factory.point(1, 0)
+      ])
+    }
+
+    assert_raises { ring.call RGeo::Geographic.simple_mercator_factory }
+
+    ring.call RGeo::Geographic.simple_mercator_factory(uses_lenient_assertions: true)
+  end
 end


### PR DESCRIPTION
Fix `:uses_lenient_assertions` flag for
`RGeo::Geographic.simple_mercator_factory`.

fixes rgeo/rgeo#277
