### PR TITLE
Pass uses_lenient_assertions option to projected factory

### DIFF
--- a/lib/rgeo/geographic/interface.rb
+++ b/lib/rgeo/geographic/interface.rb
@@ -441,7 +441,8 @@ module RGeo
             has_z_coordinate: opts[:has_z_coordinate],
             has_m_coordinate: opts[:has_m_coordinate],
             wkt_parser: opts[:wkt_parser], wkt_generator: opts[:wkt_generator],
-            wkb_parser: opts[:wkb_parser], wkb_generator: opts[:wkb_generator])
+            wkb_parser: opts[:wkb_parser], wkb_generator: opts[:wkb_generator],
+            uses_lenient_assertions: opts[:uses_lenient_assertions])
           projector = Geographic::Proj4Projector.create_from_proj4(factory,
             projection_proj4,
             srid: projection_srid,


### PR DESCRIPTION
### Summary

`RGeo::Geographic.spherical_factory` and `RGeo::Geographic.simple_mercator_factory` both pass the `uses_lenient_assertions` option to the `Geographic::Factory` constructor, but `RGeo::Geographic.projected_factory` does not. This pull request updates `RGeo::Geographic.projected_factory` to also pass the `uses_lenient_assertions` option through to the `Geographic::Factory` constructor.

### Other Information

I know that the RGeo team intends to get rid of `uses_lenient_assertions` in version 3.0. This is just intended as a stopgap fix until 3.0 lands.

I couldn't find an existing test for `RGeo::Geographic.projected_factory`, so I didn't add a test for this. I did a little manual testing and everything seems to work. It seems pretty low-risk, but I defer to your judgement.