### PR TITLE
Refactor globals and GC mark them

### DIFF
--- a/ext/geos_c_impl/analysis.c
+++ b/ext/geos_c_impl/analysis.c
@@ -9,6 +9,8 @@
 #include <ruby.h>
 #include <geos_c.h>
 
+#include "globals.h"
+
 #include "analysis.h"
 #include "factory.h"
 #include "errors.h"
@@ -62,11 +64,11 @@ VALUE rgeo_geos_analysis_supports_ccw(VALUE self)
 }
 
 
-void rgeo_init_geos_analysis(RGeo_Globals* globals)
+void rgeo_init_geos_analysis()
 {
   VALUE geos_analysis_module;
 
-  geos_analysis_module = rb_define_module_under(globals->geos_module, "Analysis");
+  geos_analysis_module = rb_define_module_under(rgeo_geos_module, "Analysis");
   rb_define_singleton_method(geos_analysis_module, "ccw_supported?", rgeo_geos_analysis_supports_ccw, 0);
   #ifdef RGEO_GEOS_SUPPORTS_ISCCW
   rb_define_singleton_method(geos_analysis_module, "ccw?", rgeo_geos_analysis_ccw_p, 1);

--- a/ext/geos_c_impl/analysis.h
+++ b/ext/geos_c_impl/analysis.h
@@ -9,8 +9,6 @@
 
 #ifdef RGEO_GEOS_SUPPORTED
 
-#include "factory.h"
-
 RGEO_BEGIN_C
 
 /*
@@ -33,7 +31,7 @@ VALUE rgeo_geos_analysis_ccw_p(VALUE self, VALUE ring);
  */
 VALUE rgeo_geos_analysis_supports_ccw(VALUE self);
 
-void rgeo_init_geos_analysis(RGeo_Globals* globals);
+void rgeo_init_geos_analysis();
 
 RGEO_END_C
 

--- a/ext/geos_c_impl/errors.c
+++ b/ext/geos_c_impl/errors.c
@@ -8,6 +8,8 @@
 
 #ifdef RGEO_GEOS_SUPPORTED
 
+#include "globals.h"
+
 #include "errors.h"
 
 RGEO_BEGIN_C
@@ -19,10 +21,8 @@ VALUE geos_error;
 
 
 void rgeo_init_geos_errors() {
-  VALUE rgeo_module;
   VALUE error_module;
 
-  rgeo_module = rb_define_module("RGeo");
   error_module = rb_define_module_under(rgeo_module, "Error");
   rgeo_error = rb_define_class_under(error_module, "RGeoError", rb_eRuntimeError);
   geos_error = rb_define_class_under(error_module, "GeosError", rgeo_error);

--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -11,57 +11,12 @@
 RGEO_BEGIN_C
 
 /*
-  Per-interpreter globals.
-  Most of these are cached references to commonly used classes, modules,
-  and symbols so we don't have to do a lot of constant lookups and calls
-  to rb_intern.
-*/
-typedef struct {
-  VALUE feature_module;
-  VALUE feature_geometry;
-  VALUE feature_point;
-  VALUE feature_line_string;
-  VALUE feature_linear_ring;
-  VALUE feature_line;
-  VALUE feature_polygon;
-  VALUE feature_geometry_collection;
-  VALUE feature_multi_point;
-  VALUE feature_multi_line_string;
-  VALUE feature_multi_polygon;
-  VALUE geos_module;
-  VALUE geos_geometry;
-  VALUE geos_point;
-  VALUE geos_line_string;
-  VALUE geos_linear_ring;
-  VALUE geos_line;
-  VALUE geos_polygon;
-  VALUE geos_geometry_collection;
-  VALUE geos_multi_point;
-  VALUE geos_multi_line_string;
-  VALUE geos_multi_polygon;
-  ID id_cast;
-  ID id_eql;
-  ID id_generate;
-  ID id_enum_for;
-  ID id_hash;
-  VALUE sym_force_new;
-  VALUE sym_keep_subtype;
-#ifndef RGEO_GEOS_SUPPORTS_SETOUTPUTDIMENSION
-  VALUE psych_wkt_generator;
-  VALUE marshal_wkb_generator;
-#endif
-} RGeo_Globals;
-
-
-/*
   Wrapped structure for Factory objects.
   A factory encapsulates the GEOS context, and GEOS serializer settings.
   It also stores the SRID for all geometries created by this factory,
   and the resolution for buffers created for this factory's geometries.
-  Finally, it provides easy access to the globals.
 */
 typedef struct {
-  RGeo_Globals* globals;
   GEOSContextHandle_t geos_context;
   GEOSWKTReader* wkt_reader;
   GEOSWKBReader* wkb_reader;
@@ -120,18 +75,6 @@ typedef struct {
 
 
 // Data types which indicate how RGeo types should be managed by Ruby.
-static void destroy_globals_func(RGeo_Globals* data);
-
-static void mark_globals_func(RGeo_Globals* data);
-
-static const rb_data_type_t rgeo_globals_type = {
-  .wrap_struct_name = "RGeo/Globals",
-  .function = {
-    .dmark = mark_globals_func,
-    .dfree = destroy_globals_func
-  }
-};
-
 static void destroy_factory_func(RGeo_FactoryData* data);
 
 static void mark_factory_func(RGeo_FactoryData* data);
@@ -173,7 +116,7 @@ static const rb_data_type_t rgeo_geometry_type = {
   Initializes the factory module. This should be called first in the
   initialization process.
 */
-RGeo_Globals* rgeo_init_geos_factory();
+void rgeo_init_geos_factory();
 
 /*
   Given a GEOS geometry handle, wraps it in a ruby Geometry object of the

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -11,6 +11,8 @@
 #include <ruby.h>
 #include <geos_c.h>
 
+#include "globals.h"
+
 #include "factory.h"
 #include "geometry.h"
 
@@ -180,13 +182,11 @@ static VALUE method_geometry_geometry_type(VALUE self)
 {
   VALUE result;
   RGeo_GeometryData* self_data;
-  const GEOSGeometry* self_geom;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
-  self_geom = self_data->geom;
-  if (self_geom) {
-    result = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->feature_geometry;
+  if (self_data->geom) {
+    result = rgeo_feature_geometry_module;
   }
   return result;
 }
@@ -271,7 +271,7 @@ static VALUE method_geometry_as_text(VALUE self)
     factory_data = RGEO_FACTORY_DATA_PTR(self_data->factory);
     wkt_generator = factory_data->wkrep_wkt_generator;
     if (!NIL_P(wkt_generator)) {
-      result = rb_funcall(wkt_generator, factory_data->globals->id_generate, 1, self);
+      result = rb_funcall(wkt_generator, rb_intern("generate"), 1, self);
     }
     else {
       wkt_writer = factory_data->wkt_writer;
@@ -310,7 +310,7 @@ static VALUE method_geometry_as_binary(VALUE self)
     factory_data = RGEO_FACTORY_DATA_PTR(self_data->factory);
     wkb_generator = factory_data->wkrep_wkb_generator;
     if (!NIL_P(wkb_generator)) {
-      result = rb_funcall(wkb_generator, factory_data->globals->id_generate, 1, self);
+      result = rb_funcall(wkb_generator, rb_intern("generate"), 1, self);
     }
     else {
       wkb_writer = factory_data->wkb_writer;
@@ -1075,11 +1075,11 @@ static VALUE method_geometry_point_on_surface(VALUE self)
 /**** INITIALIZATION FUNCTION ****/
 
 
-void rgeo_init_geos_geometry(RGeo_Globals* globals)
+void rgeo_init_geos_geometry()
 {
   VALUE geos_geometry_methods;
 
-  geos_geometry_methods = rb_define_module_under(globals->geos_module, "CAPIGeometryMethods");
+  geos_geometry_methods = rb_define_module_under(rgeo_geos_module, "CAPIGeometryMethods");
 
   rb_define_method(geos_geometry_methods, "factory=", method_geometry_set_factory, 1);
   rb_define_method(geos_geometry_methods, "initialize_copy", method_geometry_initialize_copy, 1);

--- a/ext/geos_c_impl/geometry.h
+++ b/ext/geos_c_impl/geometry.h
@@ -6,8 +6,6 @@
 #ifndef RGEO_GEOS_GEOMETRY_INCLUDED
 #define RGEO_GEOS_GEOMETRY_INCLUDED
 
-#include "factory.h"
-
 RGEO_BEGIN_C
 
 
@@ -15,7 +13,7 @@ RGEO_BEGIN_C
   Initializes the geometry module. This should be called after the factory
   module is initialized, but before any of the other modules.
 */
-void rgeo_init_geos_geometry(RGeo_Globals* globals);
+void rgeo_init_geos_geometry();
 
 
 RGEO_END_C

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -10,6 +10,8 @@
 #include <ruby.h>
 #include <geos_c.h>
 
+#include "globals.h"
+
 #include "factory.h"
 #include "geometry.h"
 #include "line_string.h"
@@ -56,13 +58,13 @@ static VALUE create_geometry_collection(VALUE module, int type, VALUE factory, V
     cast_type = Qnil;
     switch (type) {
     case GEOS_MULTIPOINT:
-      cast_type = factory_data->globals->feature_point;
+      cast_type = rgeo_feature_point_module;
       break;
     case GEOS_MULTILINESTRING:
-      cast_type = factory_data->globals->feature_line_string;
+      cast_type = rgeo_feature_line_string_module;
       break;
     case GEOS_MULTIPOLYGON:
-      cast_type = factory_data->globals->feature_polygon;
+      cast_type = rgeo_feature_polygon_module;
       break;
     }
     for (i=0; i<len; ++i) {
@@ -156,8 +158,7 @@ static VALUE method_geometry_collection_hash(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   factory = self_data->factory;
   hash = rb_hash_start(0);
-  hash = rgeo_geos_objbase_hash(factory,
-    RGEO_FACTORY_DATA_PTR(factory)->globals->feature_geometry_collection, hash);
+  hash = rgeo_geos_objbase_hash(factory, rgeo_feature_geometry_collection_module, hash);
   hash = rgeo_geos_geometry_collection_hash(self_data->geos_context, self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
@@ -171,7 +172,7 @@ static VALUE method_geometry_collection_geometry_type(VALUE self)
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   if (self_data->geom) {
-    result = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->feature_geometry_collection;
+    result = rgeo_feature_geometry_collection_module;
   }
   return result;
 }
@@ -239,6 +240,8 @@ static VALUE method_geometry_collection_brackets(VALUE self, VALUE n)
 
 static VALUE method_geometry_collection_each(VALUE self)
 {
+  RETURN_ENUMERATOR(self, 0, 0); /* return enum_for(__callee__) unless block_given? */
+
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
   int len;
@@ -249,27 +252,22 @@ static VALUE method_geometry_collection_each(VALUE self)
 
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
 
-  if (rb_block_given_p()) {
-    self_geom = self_data->geom;
-    if (self_geom) {
-      GEOSContextHandle_t self_context = self_data->geos_context;
-      len = GEOSGetNumGeometries_r(self_context, self_geom);
-      if (len > 0) {
-        klasses = self_data->klasses;
-        for (i=0; i<len; ++i) {
-          elem_geom = GEOSGetGeometryN_r(self_context, self_geom, i);
-          elem = rgeo_wrap_geos_geometry_clone(self_data->factory, elem_geom, NIL_P(klasses) ? Qnil : rb_ary_entry(klasses, i));
-          if (!NIL_P(elem)) {
-            rb_yield(elem);
-          }
+  self_geom = self_data->geom;
+  if (self_geom) {
+    GEOSContextHandle_t self_context = self_data->geos_context;
+    len = GEOSGetNumGeometries_r(self_context, self_geom);
+    if (len > 0) {
+      klasses = self_data->klasses;
+      for (i=0; i<len; ++i) {
+        elem_geom = GEOSGetGeometryN_r(self_context, self_geom, i);
+        elem = rgeo_wrap_geos_geometry_clone(self_data->factory, elem_geom, NIL_P(klasses) ? Qnil : rb_ary_entry(klasses, i));
+        if (!NIL_P(elem)) {
+          rb_yield(elem);
         }
       }
     }
-    return self;
   }
-  else {
-    return rb_funcall(self, RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->id_enum_for, 0);
-  }
+  return self;
 }
 
 static VALUE method_multi_point_geometry_type(VALUE self)
@@ -280,7 +278,7 @@ static VALUE method_multi_point_geometry_type(VALUE self)
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   if (self_data->geom) {
-    result = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->feature_multi_point;
+    result = rgeo_feature_multi_point_module;
   }
   return result;
 }
@@ -295,8 +293,7 @@ static VALUE method_multi_point_hash(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   factory = self_data->factory;
   hash = rb_hash_start(0);
-  hash = rgeo_geos_objbase_hash(factory,
-    RGEO_FACTORY_DATA_PTR(factory)->globals->feature_multi_point, hash);
+  hash = rgeo_geos_objbase_hash(factory, rgeo_feature_multi_point_module, hash);
   hash = rgeo_geos_geometry_collection_hash(self_data->geos_context, self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
@@ -342,7 +339,7 @@ static VALUE method_multi_line_string_geometry_type(VALUE self)
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   if (self_data->geom) {
-    result = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->feature_multi_line_string;
+    result = rgeo_feature_multi_line_string_module;
   }
   return result;
 }
@@ -357,8 +354,7 @@ static VALUE method_multi_line_string_hash(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   factory = self_data->factory;
   hash = rb_hash_start(0);
-  hash = rgeo_geos_objbase_hash(factory,
-    RGEO_FACTORY_DATA_PTR(factory)->globals->feature_multi_line_string, hash);
+  hash = rgeo_geos_objbase_hash(factory, rgeo_feature_multi_line_string_module, hash);
   hash = rgeo_geos_geometry_collection_hash(self_data->geos_context, self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
@@ -396,7 +392,7 @@ static VALUE method_multi_line_string_coordinates(VALUE self)
 
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
-  
+
   if(self_geom) {
     zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
     context = self_data->geos_context;
@@ -472,7 +468,7 @@ static VALUE method_multi_polygon_geometry_type(VALUE self)
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   if (self_data->geom) {
-    result = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->feature_multi_polygon;
+    result = rgeo_feature_multi_polygon_module;
   }
   return result;
 }
@@ -487,8 +483,7 @@ static VALUE method_multi_polygon_hash(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   factory = self_data->factory;
   hash = rb_hash_start(0);
-  hash = rgeo_geos_objbase_hash(factory,
-    RGEO_FACTORY_DATA_PTR(factory)->globals->feature_multi_polygon, hash);
+  hash = rgeo_geos_objbase_hash(factory, rgeo_feature_multi_polygon_module, hash);
   hash = rgeo_geos_geometry_collection_hash(self_data->geos_context, self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
@@ -508,7 +503,7 @@ static VALUE method_multi_polygon_coordinates(VALUE self)
 
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
-  
+
   if(self_geom) {
     zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
     context = self_data->geos_context;
@@ -586,7 +581,7 @@ static VALUE cmethod_multi_polygon_create(VALUE module, VALUE factory, VALUE arr
 /**** INITIALIZATION FUNCTION ****/
 
 
-void rgeo_init_geos_geometry_collection(RGeo_Globals* globals)
+void rgeo_init_geos_geometry_collection()
 {
   VALUE geos_geometry_collection_methods;
   VALUE geos_multi_point_methods;
@@ -594,13 +589,13 @@ void rgeo_init_geos_geometry_collection(RGeo_Globals* globals)
   VALUE geos_multi_polygon_methods;
 
   // Class methods for geometry collection classes
-  rb_define_module_function(globals->geos_geometry_collection, "create", cmethod_geometry_collection_create, 2);
-  rb_define_module_function(globals->geos_multi_point, "create", cmethod_multi_point_create, 2);
-  rb_define_module_function(globals->geos_multi_line_string, "create", cmethod_multi_line_string_create, 2);
-  rb_define_module_function(globals->geos_multi_polygon, "create", cmethod_multi_polygon_create, 2);
+  rb_define_module_function(rgeo_geos_geometry_collection_class, "create", cmethod_geometry_collection_create, 2);
+  rb_define_module_function(rgeo_geos_multi_point_class, "create", cmethod_multi_point_create, 2);
+  rb_define_module_function(rgeo_geos_multi_line_string_class, "create", cmethod_multi_line_string_create, 2);
+  rb_define_module_function(rgeo_geos_multi_polygon_class, "create", cmethod_multi_polygon_create, 2);
 
   // Methods for GeometryCollectionImpl
-  geos_geometry_collection_methods = rb_define_module_under(globals->geos_module, "CAPIGeometryCollectionMethods");
+  geos_geometry_collection_methods = rb_define_module_under(rgeo_geos_module, "CAPIGeometryCollectionMethods");
   rb_define_method(geos_geometry_collection_methods, "rep_equals?", method_geometry_collection_eql, 1);
   rb_define_method(geos_geometry_collection_methods, "eql?", method_geometry_collection_eql, 1);
   rb_define_method(geos_geometry_collection_methods, "hash", method_geometry_collection_hash, 0);
@@ -614,13 +609,13 @@ void rgeo_init_geos_geometry_collection(RGeo_Globals* globals)
 
 
   // Methods for MultiPointImpl
-  geos_multi_point_methods = rb_define_module_under(globals->geos_module, "CAPIMultiPointMethods");
+  geos_multi_point_methods = rb_define_module_under(rgeo_geos_module, "CAPIMultiPointMethods");
   rb_define_method(geos_multi_point_methods, "geometry_type", method_multi_point_geometry_type, 0);
   rb_define_method(geos_multi_point_methods, "hash", method_multi_point_hash, 0);
   rb_define_method(geos_multi_point_methods, "coordinates", method_multi_point_coordinates, 0);
 
   // Methods for MultiLineStringImpl
-  geos_multi_line_string_methods = rb_define_module_under(globals->geos_module, "CAPIMultiLineStringMethods");
+  geos_multi_line_string_methods = rb_define_module_under(rgeo_geos_module, "CAPIMultiLineStringMethods");
   rb_define_method(geos_multi_line_string_methods, "geometry_type", method_multi_line_string_geometry_type, 0);
   rb_define_method(geos_multi_line_string_methods, "length", method_multi_line_string_length, 0);
   rb_define_method(geos_multi_line_string_methods, "closed?", method_multi_line_string_is_closed, 0);
@@ -628,7 +623,7 @@ void rgeo_init_geos_geometry_collection(RGeo_Globals* globals)
   rb_define_method(geos_multi_line_string_methods, "coordinates", method_multi_line_string_coordinates, 0);
 
   // Methods for MultiPolygonImpl
-  geos_multi_polygon_methods = rb_define_module_under(globals->geos_module, "CAPIMultiPolygonMethods");
+  geos_multi_polygon_methods = rb_define_module_under(rgeo_geos_module, "CAPIMultiPolygonMethods");
   rb_define_method(geos_multi_polygon_methods, "geometry_type", method_multi_polygon_geometry_type, 0);
   rb_define_method(geos_multi_polygon_methods, "area", method_multi_polygon_area, 0);
   rb_define_method(geos_multi_polygon_methods, "centroid", method_multi_polygon_centroid, 0);

--- a/ext/geos_c_impl/geometry_collection.h
+++ b/ext/geos_c_impl/geometry_collection.h
@@ -9,8 +9,6 @@
 #include <ruby.h>
 #include <geos_c.h>
 
-#include "factory.h"
-
 RGEO_BEGIN_C
 
 
@@ -18,7 +16,7 @@ RGEO_BEGIN_C
   Initializes the geometry collection module. This should be called after
   the geometry module is initialized.
 */
-void rgeo_init_geos_geometry_collection(RGeo_Globals* globals);
+void rgeo_init_geos_geometry_collection();
 
 /*
   Comopares the contents of two geometry collections. Does not test the

--- a/ext/geos_c_impl/globals.c
+++ b/ext/geos_c_impl/globals.c
@@ -1,0 +1,91 @@
+#include "preface.h"
+
+#ifdef RGEO_GEOS_SUPPORTED
+
+#include <ruby.h>
+
+#include "globals.h"
+
+RGEO_BEGIN_C
+
+VALUE rgeo_module;
+
+VALUE rgeo_feature_module;
+VALUE rgeo_feature_geometry_module;
+VALUE rgeo_feature_point_module;
+VALUE rgeo_feature_line_string_module;
+VALUE rgeo_feature_linear_ring_module;
+VALUE rgeo_feature_line_module;
+VALUE rgeo_feature_polygon_module;
+VALUE rgeo_feature_geometry_collection_module;
+VALUE rgeo_feature_multi_point_module;
+VALUE rgeo_feature_multi_line_string_module;
+VALUE rgeo_feature_multi_polygon_module;
+
+VALUE rgeo_geos_module;
+VALUE rgeo_geos_geometry_class;
+VALUE rgeo_geos_point_class;
+VALUE rgeo_geos_line_string_class;
+VALUE rgeo_geos_linear_ring_class;
+VALUE rgeo_geos_line_class;
+VALUE rgeo_geos_polygon_class;
+VALUE rgeo_geos_geometry_collection_class;
+VALUE rgeo_geos_multi_point_class;
+VALUE rgeo_geos_multi_line_string_class;
+VALUE rgeo_geos_multi_polygon_class;
+
+void rgeo_init_geos_globals()
+{
+  rgeo_module = rb_define_module("RGeo");
+  rb_gc_register_mark_object(rgeo_module);
+
+  rgeo_feature_module = rb_define_module_under(rgeo_module, "Feature");
+  rb_gc_register_mark_object(rgeo_feature_module);
+  rgeo_feature_geometry_module = rb_const_get_at(rgeo_feature_module, rb_intern("Geometry"));
+  rb_gc_register_mark_object(rgeo_feature_geometry_module);
+  rgeo_feature_point_module = rb_const_get_at(rgeo_feature_module, rb_intern("Point"));
+  rb_gc_register_mark_object(rgeo_feature_point_module);
+  rgeo_feature_line_string_module = rb_const_get_at(rgeo_feature_module, rb_intern("LineString"));
+  rb_gc_register_mark_object(rgeo_feature_line_string_module);
+  rgeo_feature_linear_ring_module = rb_const_get_at(rgeo_feature_module, rb_intern("LinearRing"));
+  rb_gc_register_mark_object(rgeo_feature_linear_ring_module);
+  rgeo_feature_line_module = rb_const_get_at(rgeo_feature_module, rb_intern("Line"));
+  rb_gc_register_mark_object(rgeo_feature_line_module);
+  rgeo_feature_polygon_module = rb_const_get_at(rgeo_feature_module, rb_intern("Polygon"));
+  rb_gc_register_mark_object(rgeo_feature_polygon_module);
+  rgeo_feature_geometry_collection_module = rb_const_get_at(rgeo_feature_module, rb_intern("GeometryCollection"));
+  rb_gc_register_mark_object(rgeo_feature_geometry_collection_module);
+  rgeo_feature_multi_point_module = rb_const_get_at(rgeo_feature_module, rb_intern("MultiPoint"));
+  rb_gc_register_mark_object(rgeo_feature_multi_point_module);
+  rgeo_feature_multi_line_string_module = rb_const_get_at(rgeo_feature_module, rb_intern("MultiLineString"));
+  rb_gc_register_mark_object(rgeo_feature_multi_line_string_module);
+  rgeo_feature_multi_polygon_module = rb_const_get_at(rgeo_feature_module, rb_intern("MultiPolygon"));
+  rb_gc_register_mark_object(rgeo_feature_multi_polygon_module);
+
+  rgeo_geos_module = rb_define_module_under(rgeo_module, "Geos");
+  rb_gc_register_mark_object(rgeo_geos_module);
+  rgeo_geos_geometry_class = rb_define_class_under(rgeo_geos_module, "CAPIGeometryImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_geometry_class);
+  rgeo_geos_point_class = rb_define_class_under(rgeo_geos_module, "CAPIPointImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_point_class);
+  rgeo_geos_line_string_class = rb_define_class_under(rgeo_geos_module, "CAPILineStringImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_line_string_class);
+  rgeo_geos_linear_ring_class = rb_define_class_under(rgeo_geos_module, "CAPILinearRingImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_linear_ring_class);
+  rgeo_geos_line_class = rb_define_class_under(rgeo_geos_module, "CAPILineImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_line_class);
+  rgeo_geos_polygon_class = rb_define_class_under(rgeo_geos_module, "CAPIPolygonImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_polygon_class);
+  rgeo_geos_geometry_collection_class = rb_define_class_under(rgeo_geos_module, "CAPIGeometryCollectionImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_geometry_collection_class);
+  rgeo_geos_multi_point_class = rb_define_class_under(rgeo_geos_module, "CAPIMultiPointImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_multi_point_class);
+  rgeo_geos_multi_line_string_class = rb_define_class_under(rgeo_geos_module, "CAPIMultiLineStringImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_multi_line_string_class);
+  rgeo_geos_multi_polygon_class = rb_define_class_under(rgeo_geos_module, "CAPIMultiPolygonImpl", rb_cObject);
+  rb_gc_register_mark_object(rgeo_geos_multi_polygon_class);
+}
+
+RGEO_END_C
+
+#endif

--- a/ext/geos_c_impl/globals.h
+++ b/ext/geos_c_impl/globals.h
@@ -1,0 +1,45 @@
+/*
+  Per-interpreter globals.
+  Most of these are cached references to commonly used classes, modules,
+  and symbols so we don't have to do a lot of constant lookups and calls
+  to rb_intern.
+*/
+
+#ifndef RGEO_GEOS_GLOBALS_INCLUDED
+#define RGEO_GEOS_GLOBALS_INCLUDED
+
+#include <ruby.h>
+
+RGEO_BEGIN_C
+
+extern VALUE rgeo_module;
+
+extern VALUE rgeo_feature_module;
+extern VALUE rgeo_feature_geometry_module;
+extern VALUE rgeo_feature_point_module;
+extern VALUE rgeo_feature_line_string_module;
+extern VALUE rgeo_feature_linear_ring_module;
+extern VALUE rgeo_feature_line_module;
+extern VALUE rgeo_feature_polygon_module;
+extern VALUE rgeo_feature_geometry_collection_module;
+extern VALUE rgeo_feature_multi_point_module;
+extern VALUE rgeo_feature_multi_line_string_module;
+extern VALUE rgeo_feature_multi_polygon_module;
+
+extern VALUE rgeo_geos_module;
+extern VALUE rgeo_geos_geometry_class;
+extern VALUE rgeo_geos_point_class;
+extern VALUE rgeo_geos_line_string_class;
+extern VALUE rgeo_geos_linear_ring_class;
+extern VALUE rgeo_geos_line_class;
+extern VALUE rgeo_geos_polygon_class;
+extern VALUE rgeo_geos_geometry_collection_class;
+extern VALUE rgeo_geos_multi_point_class;
+extern VALUE rgeo_geos_multi_line_string_class;
+extern VALUE rgeo_geos_multi_polygon_class;
+
+void rgeo_init_geos_globals();
+
+RGEO_END_C
+
+#endif

--- a/ext/geos_c_impl/line_string.c
+++ b/ext/geos_c_impl/line_string.c
@@ -11,6 +11,8 @@
 #include <ruby.h>
 #include <geos_c.h>
 
+#include "globals.h"
+
 #include "factory.h"
 #include "geometry.h"
 #include "point.h"
@@ -29,7 +31,7 @@ static VALUE method_line_string_geometry_type(VALUE self)
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   if (self_data->geom) {
-    result = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->feature_line_string;
+    result = rgeo_feature_line_string_module;
   }
   return result;
 }
@@ -43,7 +45,7 @@ static VALUE method_linear_ring_geometry_type(VALUE self)
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   if (self_data->geom) {
-    result = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->feature_linear_ring;
+    result = rgeo_feature_linear_ring_module;
   }
   return result;
 }
@@ -57,7 +59,7 @@ static VALUE method_line_geometry_type(VALUE self)
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   if (self_data->geom) {
-    result = RGEO_FACTORY_DATA_PTR(self_data->factory)->globals->feature_line;
+    result = rgeo_feature_line_module;
   }
   return result;
 }
@@ -264,7 +266,7 @@ static VALUE method_line_string_project_point(VALUE self, VALUE point)
   factory_data = RGEO_FACTORY_DATA_PTR(factory);
 
   if(self_geom && point) {
-    geos_point = rgeo_convert_to_geos_geometry(factory, point, factory_data->globals->geos_point);
+    geos_point = rgeo_convert_to_geos_geometry(factory, point, rgeo_geos_point_class);
     location = GEOSProject_r(self_data->geos_context, self_geom, geos_point);
     result = DBL2NUM(location);
   }
@@ -290,7 +292,7 @@ static VALUE method_line_string_interpolate_point(VALUE self, VALUE loc_num)
 
   if(self_geom) {
     geos_point = GEOSInterpolate_r(self_data->geos_context, self_geom, location);
-    result = rgeo_wrap_geos_geometry(factory, geos_point, factory_data->globals->geos_point);
+    result = rgeo_wrap_geos_geometry(factory, geos_point, rgeo_geos_point_class);
   }
 
   return result;
@@ -358,8 +360,7 @@ static VALUE method_line_string_hash(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   factory = self_data->factory;
   hash = rb_hash_start(0);
-  hash = rgeo_geos_objbase_hash(factory,
-    RGEO_FACTORY_DATA_PTR(factory)->globals->feature_line_string, hash);
+  hash = rgeo_geos_objbase_hash(factory, rgeo_feature_line_string_module, hash);
   hash = rgeo_geos_coordseq_hash(self_data->geos_context, self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
@@ -374,8 +375,7 @@ static VALUE method_linear_ring_hash(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   factory = self_data->factory;
   hash = rb_hash_start(0);
-  hash = rgeo_geos_objbase_hash(factory,
-    RGEO_FACTORY_DATA_PTR(factory)->globals->feature_linear_ring, hash);
+  hash = rgeo_geos_objbase_hash(factory, rgeo_feature_linear_ring_module, hash);
   hash = rgeo_geos_coordseq_hash(self_data->geos_context, self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
@@ -390,8 +390,7 @@ static VALUE method_line_hash(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   factory = self_data->factory;
   hash = rb_hash_start(0);
-  hash = rgeo_geos_objbase_hash(factory,
-    RGEO_FACTORY_DATA_PTR(factory)->globals->feature_line, hash);
+  hash = rgeo_geos_objbase_hash(factory, rgeo_feature_line_module, hash);
   hash = rgeo_geos_coordseq_hash(self_data->geos_context, self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
@@ -415,7 +414,7 @@ static GEOSCoordSequence* coord_seq_from_array(VALUE factory, VALUE array, char 
 
   Check_Type(array, T_ARRAY);
   factory_data = RGEO_FACTORY_DATA_PTR(factory);
-  point_type = factory_data->globals->feature_point;
+  point_type = rgeo_feature_point_module;
   len = (unsigned int)RARRAY_LEN(array);
   has_z = (char)(RGEO_FACTORY_DATA_PTR(factory)->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M);
   dims = has_z ? 3 : 2;
@@ -491,7 +490,7 @@ static VALUE cmethod_create_line_string(VALUE module, VALUE factory, VALUE array
     factory_data = RGEO_FACTORY_DATA_PTR(factory);
     geom = GEOSGeom_createLineString_r(factory_data->geos_context, coord_seq);
     if (geom) {
-      result = rgeo_wrap_geos_geometry(factory, geom, factory_data->globals->geos_line_string);
+      result = rgeo_wrap_geos_geometry(factory, geom, rgeo_geos_line_string_class);
     }
   }
   return result;
@@ -511,7 +510,7 @@ static VALUE cmethod_create_linear_ring(VALUE module, VALUE factory, VALUE array
     factory_data = RGEO_FACTORY_DATA_PTR(factory);
     geom = GEOSGeom_createLinearRing_r(factory_data->geos_context, coord_seq);
     if (geom) {
-      result = rgeo_wrap_geos_geometry(factory, geom, factory_data->globals->geos_linear_ring);
+      result = rgeo_wrap_geos_geometry(factory, geom, rgeo_geos_linear_ring_class);
     }
   }
   return result;
@@ -557,7 +556,7 @@ static VALUE cmethod_create_line(VALUE module, VALUE factory, VALUE start, VALUE
   result = Qnil;
   factory_data = RGEO_FACTORY_DATA_PTR(factory);
   has_z = (char)(factory_data->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M);
-  point_type = factory_data->globals->feature_point;
+  point_type = rgeo_feature_point_module;
   context = factory_data->geos_context;
 
   start_geom = rgeo_convert_to_geos_geometry(factory, start, point_type);
@@ -570,7 +569,7 @@ static VALUE cmethod_create_line(VALUE module, VALUE factory, VALUE start, VALUE
         populate_geom_into_coord_seq(context, end_geom, coord_seq, 1, has_z);
         geom = GEOSGeom_createLineString_r(context, coord_seq);
         if (geom) {
-          result = rgeo_wrap_geos_geometry(factory, geom, factory_data->globals->geos_line);
+          result = rgeo_wrap_geos_geometry(factory, geom, rgeo_geos_line_class);
         }
       }
     }
@@ -631,26 +630,26 @@ static VALUE cmethod_linear_ring_copy_from(VALUE klass, VALUE factory, VALUE ori
 }
 
 
-void rgeo_init_geos_line_string(RGeo_Globals* globals)
+void rgeo_init_geos_line_string()
 {
   VALUE geos_line_string_methods;
   VALUE geos_linear_ring_methods;
   VALUE geos_line_methods;
 
   // Class methods for CAPILineStringImpl
-  rb_define_module_function(globals->geos_line_string, "create", cmethod_create_line_string, 2);
-  rb_define_module_function(globals->geos_line_string, "_copy_from", cmethod_line_string_copy_from, 2);
+  rb_define_module_function(rgeo_geos_line_string_class, "create", cmethod_create_line_string, 2);
+  rb_define_module_function(rgeo_geos_line_string_class, "_copy_from", cmethod_line_string_copy_from, 2);
 
   // Class methods for CAPILinearRingImpl
-  rb_define_module_function(globals->geos_linear_ring, "create", cmethod_create_linear_ring, 2);
-  rb_define_module_function(globals->geos_linear_ring, "_copy_from", cmethod_linear_ring_copy_from, 2);
+  rb_define_module_function(rgeo_geos_linear_ring_class, "create", cmethod_create_linear_ring, 2);
+  rb_define_module_function(rgeo_geos_linear_ring_class, "_copy_from", cmethod_linear_ring_copy_from, 2);
 
   // Class methods for CAPILineImpl
-  rb_define_module_function(globals->geos_line, "create", cmethod_create_line, 3);
-  rb_define_module_function(globals->geos_line, "_copy_from", cmethod_line_copy_from, 2);
+  rb_define_module_function(rgeo_geos_line_class, "create", cmethod_create_line, 3);
+  rb_define_module_function(rgeo_geos_line_class, "_copy_from", cmethod_line_copy_from, 2);
 
   // CAPILineStringMethods module
-  geos_line_string_methods = rb_define_module_under(globals->geos_module, "CAPILineStringMethods");
+  geos_line_string_methods = rb_define_module_under(rgeo_geos_module, "CAPILineStringMethods");
   rb_define_method(geos_line_string_methods, "rep_equals?", method_line_string_eql, 1);
   rb_define_method(geos_line_string_methods, "eql?", method_line_string_eql, 1);
   rb_define_method(geos_line_string_methods, "hash", method_line_string_hash, 0);
@@ -668,12 +667,12 @@ void rgeo_init_geos_line_string(RGeo_Globals* globals)
   rb_define_method(geos_line_string_methods, "coordinates", method_line_string_coordinates, 0);
 
   // CAPILinearRingMethods module
-  geos_linear_ring_methods = rb_define_module_under(globals->geos_module, "CAPILinearRingMethods");
+  geos_linear_ring_methods = rb_define_module_under(rgeo_geos_module, "CAPILinearRingMethods");
   rb_define_method(geos_linear_ring_methods, "geometry_type", method_linear_ring_geometry_type, 0);
   rb_define_method(geos_linear_ring_methods, "hash", method_linear_ring_hash, 0);
 
   // CAPILineMethods module
-  geos_line_methods = rb_define_module_under(globals->geos_module, "CAPILineMethods");
+  geos_line_methods = rb_define_module_under(rgeo_geos_module, "CAPILineMethods");
   rb_define_method(geos_line_methods, "geometry_type", method_line_geometry_type, 0);
   rb_define_method(geos_line_methods, "hash", method_line_hash, 0);
 }

--- a/ext/geos_c_impl/line_string.h
+++ b/ext/geos_c_impl/line_string.h
@@ -9,8 +9,6 @@
 #include <ruby.h>
 #include <geos_c.h>
 
-#include "factory.h"
-
 RGEO_BEGIN_C
 
 
@@ -18,7 +16,7 @@ RGEO_BEGIN_C
   Initializes the line string module. This should be called after
   the geometry module is initialized.
 */
-void rgeo_init_geos_line_string(RGeo_Globals* globals);
+void rgeo_init_geos_line_string();
 
 /*
   Determines whether the given GEOS line string is closed.

--- a/ext/geos_c_impl/main.c
+++ b/ext/geos_c_impl/main.c
@@ -9,6 +9,8 @@
 #include <ruby.h>
 #include <geos_c.h>
 
+#include "globals.h"
+
 #include "errors.h"
 
 #include "factory.h"
@@ -26,15 +28,14 @@ RGEO_BEGIN_C
 void Init_geos_c_impl()
 {
 #ifdef RGEO_GEOS_SUPPORTED
-  RGeo_Globals* globals;
-
-  globals = rgeo_init_geos_factory();
-  rgeo_init_geos_geometry(globals);
-  rgeo_init_geos_point(globals);
-  rgeo_init_geos_line_string(globals);
-  rgeo_init_geos_polygon(globals);
-  rgeo_init_geos_geometry_collection(globals);
-  rgeo_init_geos_analysis(globals);
+  rgeo_init_geos_globals();
+  rgeo_init_geos_factory();
+  rgeo_init_geos_geometry();
+  rgeo_init_geos_point();
+  rgeo_init_geos_line_string();
+  rgeo_init_geos_polygon();
+  rgeo_init_geos_geometry_collection();
+  rgeo_init_geos_analysis();
   rgeo_init_geos_errors();
 #endif
 }

--- a/ext/geos_c_impl/point.h
+++ b/ext/geos_c_impl/point.h
@@ -8,8 +8,6 @@
 
 #include <ruby.h>
 
-#include "factory.h"
-
 RGEO_BEGIN_C
 
 
@@ -17,7 +15,7 @@ RGEO_BEGIN_C
   Initializes the point module. This should be called after
   the geometry module is initialized.
 */
-void rgeo_init_geos_point(RGeo_Globals* globals);
+void rgeo_init_geos_point();
 
 /*
   Creates a 3d point and returns the ruby object.

--- a/ext/geos_c_impl/polygon.h
+++ b/ext/geos_c_impl/polygon.h
@@ -9,8 +9,6 @@
 #include <ruby.h>
 #include <geos_c.h>
 
-#include "factory.h"
-
 RGEO_BEGIN_C
 
 
@@ -18,7 +16,7 @@ RGEO_BEGIN_C
   Initializes the polygon module. This should be called after
   the geometry module is initialized.
 */
-void rgeo_init_geos_polygon(RGeo_Globals* globals);
+void rgeo_init_geos_polygon();
 
 /*
   Comopares the values of two GEOS polygons. The two given geometries MUST

--- a/test/geos_ffi/factory_test.rb
+++ b/test/geos_ffi/factory_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "../test_helper"
 
 class GeosFFIFactoryTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::FactoryTests

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,9 @@ require_relative "common/point_tests"
 require_relative "common/polygon_tests"
 
 require "pry-byebug" if ENV["BYEBUG"]
+
+# Test for missed references in our CAPI codebase (or FFI interface).
+# See https://alanwu.space/post/check-compaction/
+if defined?(GC.verify_compaction_references) == "method"
+  GC.verify_compaction_references(double_heap: true, toward: :empty)
+end


### PR DESCRIPTION
### Summary

Refactor the globals, to make them global in C, and remove the link between factory and globals. This avoids passing references around, and treating ruby as a sort of storage for these globals.


### Reproduction

The script below would segv every time (every rgeo / geos version that can compile nowadays)

```ruby
pt=RGeo::Geos.factory.point(1,0)
RGeo::Geos::CAPIFactory::INTERNAL_CGLOBALS = nil
def polygon(pts, factory: RGeo::Geos.factory)
  pts = pts.each_slice(2) if pts.first.is_a?(Numeric) && pts.size.even?
  factory.polygon(
    ring(pts, factory: factory)
  )
end
polygon([0, 0,    0, 1,    1, 1,    1, 0,    0, 0]).contains?(pt)
```

Even though this is a pretty dumb script, pure ruby should not crash, moreover, using GC.compact a few times (or `verify_compaction_references`) would generate the same issue at some point.