### PR TITLE
Movable pointers

### DIFF
--- a/ext/geos_c_impl/extconf.rb
+++ b/ext/geos_c_impl/extconf.rb
@@ -33,6 +33,7 @@ else
     have_func("GEOSUnaryUnion_r", "geos_c.h")
     have_func("GEOSCoordSeq_isCCW_r", "geos_c.h")
     have_func("rb_memhash", "ruby.h")
+    have_func("rb_gc_mark_movable", "ruby.h")
   end
 
   if found_geos_

--- a/ext/geos_c_impl/factory.c
+++ b/ext/geos_c_impl/factory.c
@@ -98,22 +98,22 @@ static void destroy_geometry_func(RGeo_GeometryData* data)
 static void mark_factory_func(RGeo_FactoryData* data)
 {
   if (!NIL_P(data->wkrep_wkt_generator)) {
-    rb_gc_mark(data->wkrep_wkt_generator);
+    mark(data->wkrep_wkt_generator);
   }
   if (!NIL_P(data->wkrep_wkb_generator)) {
-    rb_gc_mark(data->wkrep_wkb_generator);
+    mark(data->wkrep_wkb_generator);
   }
   if (!NIL_P(data->wkrep_wkt_parser)) {
-    rb_gc_mark(data->wkrep_wkt_parser);
+    mark(data->wkrep_wkt_parser);
   }
   if (!NIL_P(data->wkrep_wkb_parser)) {
-    rb_gc_mark(data->wkrep_wkb_parser);
+    mark(data->wkrep_wkb_parser);
   }
   if (!NIL_P(data->proj4_obj)) {
-    rb_gc_mark(data->proj4_obj);
+    mark(data->proj4_obj);
   }
   if (!NIL_P(data->coord_sys_obj)) {
-    rb_gc_mark(data->coord_sys_obj);
+    mark(data->coord_sys_obj);
   }
 }
 
@@ -124,12 +124,48 @@ static void mark_factory_func(RGeo_FactoryData* data)
 static void mark_geometry_func(RGeo_GeometryData* data)
 {
   if (!NIL_P(data->factory)) {
-    rb_gc_mark(data->factory);
+    mark(data->factory);
   }
   if (!NIL_P(data->klasses)) {
-    rb_gc_mark(data->klasses);
+    mark(data->klasses);
   }
 }
+
+
+#ifdef HAVE_RB_GC_MARK_MOVABLE
+static void compact_factory_func(RGeo_FactoryData* data)
+{
+  if (!NIL_P(data->wkrep_wkt_generator)) {
+    data->wkrep_wkt_generator = rb_gc_location(data->wkrep_wkt_generator);
+  }
+  if (!NIL_P(data->wkrep_wkb_generator)) {
+    data->wkrep_wkb_generator = rb_gc_location(data->wkrep_wkb_generator);
+  }
+  if (!NIL_P(data->wkrep_wkt_parser)) {
+    data->wkrep_wkt_parser = rb_gc_location(data->wkrep_wkt_parser);
+  }
+  if (!NIL_P(data->wkrep_wkb_parser)) {
+    data->wkrep_wkb_parser = rb_gc_location(data->wkrep_wkb_parser);
+  }
+  if (!NIL_P(data->proj4_obj)) {
+    data->proj4_obj = rb_gc_location(data->proj4_obj);
+  }
+  if (!NIL_P(data->coord_sys_obj)) {
+    data->coord_sys_obj = rb_gc_location(data->coord_sys_obj);
+  }
+}
+
+
+static void compact_geometry_func(RGeo_GeometryData* data)
+{
+  if (!NIL_P(data->factory)) {
+    data->factory = rb_gc_location(data->factory);
+  }
+  if (!NIL_P(data->klasses)) {
+    data->klasses = rb_gc_location(data->klasses);
+  }
+}
+#endif
 
 
 /**** RUBY METHOD DEFINITIONS ****/

--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -75,44 +75,9 @@ typedef struct {
 
 
 // Data types which indicate how RGeo types should be managed by Ruby.
-static void destroy_factory_func(RGeo_FactoryData* data);
+extern const rb_data_type_t rgeo_factory_type;
 
-static void destroy_geometry_func(RGeo_GeometryData* data);
-
-
-static void mark_factory_func(RGeo_FactoryData* data);
-
-static void mark_geometry_func(RGeo_GeometryData* data);
-
-
-#ifdef HAVE_RB_GC_MARK_MOVABLE
-static void compact_factory_func(RGeo_FactoryData* data);
-
-static void compact_geometry_func(RGeo_GeometryData* data);
-#endif
-
-
-static const rb_data_type_t rgeo_factory_type = {
-  .wrap_struct_name = "RGeo/Factory",
-  .function = {
-    .dmark = mark_factory_func,
-    .dfree = destroy_factory_func,
-#ifdef HAVE_RB_GC_MARK_MOVABLE
-    .dcompact = compact_factory_func,
-#endif
-  }
-};
-
-static const rb_data_type_t rgeo_geometry_type = {
-  .wrap_struct_name = "RGeo/Geometry",
-  .function = {
-    .dmark = mark_geometry_func,
-    .dfree = destroy_geometry_func,
-#ifdef HAVE_RB_GC_MARK_MOVABLE
-    .dcompact = compact_geometry_func,
-#endif
-  }
-};
+extern const rb_data_type_t rgeo_geometry_type;
 
 
 // Convenient macros for checking the type of data from Ruby

--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -77,27 +77,43 @@ typedef struct {
 // Data types which indicate how RGeo types should be managed by Ruby.
 static void destroy_factory_func(RGeo_FactoryData* data);
 
+static void destroy_geometry_func(RGeo_GeometryData* data);
+
+
 static void mark_factory_func(RGeo_FactoryData* data);
+
+static void mark_geometry_func(RGeo_GeometryData* data);
+
+
+#ifdef HAVE_RB_GC_MARK_MOVABLE
+static void compact_factory_func(RGeo_FactoryData* data);
+
+static void compact_geometry_func(RGeo_GeometryData* data);
+#endif
+
 
 static const rb_data_type_t rgeo_factory_type = {
   .wrap_struct_name = "RGeo/Factory",
   .function = {
     .dmark = mark_factory_func,
-    .dfree = destroy_factory_func
+    .dfree = destroy_factory_func,
+#ifdef HAVE_RB_GC_MARK_MOVABLE
+    .dcompact = compact_factory_func,
+#endif
   }
 };
-
-static void destroy_geometry_func(RGeo_GeometryData* data);
-
-static void mark_geometry_func(RGeo_GeometryData* data);
 
 static const rb_data_type_t rgeo_geometry_type = {
   .wrap_struct_name = "RGeo/Geometry",
   .function = {
     .dmark = mark_geometry_func,
-    .dfree = destroy_geometry_func
+    .dfree = destroy_geometry_func,
+#ifdef HAVE_RB_GC_MARK_MOVABLE
+    .dcompact = compact_geometry_func,
+#endif
   }
 };
+
 
 // Convenient macros for checking the type of data from Ruby
 #define RGEO_FACTORY_TYPEDDATA_P(object) (_RGEO_TYPEDDATA_P(object, &rgeo_factory_type))

--- a/ext/geos_c_impl/preface.h
+++ b/ext/geos_c_impl/preface.h
@@ -27,6 +27,11 @@
 #ifdef HAVE_RB_MEMHASH
 #define RGEO_SUPPORTS_NEW_HASHING
 #endif
+#ifdef HAVE_RB_GC_MARK_MOVABLE
+#define mark rb_gc_mark_movable
+#else
+#define mark rb_gc_mark
+#endif
 
 #ifndef RGEO_SUPPORTS_NEW_HASHING
 #define st_index_t int

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,8 +14,14 @@ require_relative "common/polygon_tests"
 
 require "pry-byebug" if ENV["BYEBUG"]
 
-# Test for missed references in our CAPI codebase (or FFI interface).
+# Static test for missed references in our CAPI codebase (or FFI interface).
 # See https://alanwu.space/post/check-compaction/
 if defined?(GC.verify_compaction_references) == "method"
   GC.verify_compaction_references(double_heap: true, toward: :empty)
+end
+
+# Live test for our implementation of Ruby's compaction methods (rb_gc_mark_movable
+# and rb_gc_location), enabling compaction for every major collection.
+if defined?(GC.auto_compact) == "method"
+  GC.auto_compact = true
 end


### PR DESCRIPTION
### Summary

Addresses https://github.com/rgeo/rgeo/issues/280, marking pointers as movable to allow for compaction.
Tested with the following scripts :

<details>
<summary> Scripts used </summary>

To dump `ObjectSpace`:
```ruby
# frozen_string_literal: true

require "objspace"
require_relative "./lib/rgeo"

ObjectSpace.trace_object_allocations_start

def record_compaction
  3.times { GC.start }
  GC.compact

  File.open("compacted.json", "w") do |file|
    ObjectSpace.dump_all(output: file)
  end
end

class Allocator
  def initialize
    @padding = []
    @held = []
  end

  def padding(n = 5_000)
    n.times do
      @padding << allocate_geometry
    end
  end

  def hold(n = 1_000)
    n.times do
      @held << allocate_geometry
    end
  end

  def allocate_factory
    RGeo::Geos::CAPIFactory.create(wkt_parser: {})
  end

  def allocate_geometry
    factory = allocate_factory

    ring = factory.linear_ring(
      [
        factory.point(rand(0..5), rand(0..5)),
        factory.point(rand(6..10), rand(0..5)),
        factory.point(rand(6..10), rand(6..10)),
        factory.point(rand(0..5), rand(6..10))
      ]
    )

    factory.polygon(ring)
  end

  def release_padding
    @padding.clear
  end
end

a = Allocator.new

a.padding
a.hold
a.release_padding

record_compaction
```


To visualize them : a modified version o f https://github.com/tenderlove/heap-utils
</details>

Results do seem positive, the graphics below correspond to the heap, with red dots as the pinned objects. We can see an overall decrease in pinned objects.

For geometries :
before patch | after patch
----|----
8543 pinned | 3538 pinned
![before-patch-geometry](https://user-images.githubusercontent.com/36706647/149499641-4c467579-804f-493f-a506-e49f94b71f29.png) | ![before](https://user-images.githubusercontent.com/36706647/149499680-5cad8847-6e97-4e87-9e5e-0a3a00e91630.png)

For factories :
before patch | after patch
----|----
7545 pinned | 3537 pinned
![before-patch](https://user-images.githubusercontent.com/36706647/149499470-c07337e9-2fd3-40f9-a6e5-41fb4a75e7f4.png) | ![after-patch](https://user-images.githubusercontent.com/36706647/149499518-bbdf6757-9aca-452c-b1d5-0f8c100e418c.png)

As for having tests to ensure non-regression, `GC.auto_compact` is enabled (option available only on ruby 3). Major collections will be done at least once during a test suite, which will trigger compaction. By commenting out the source code in `compact_*` functions, I am encountering a SEGV once every 10 test runs roughly. This is far from being an ideal test case but can serve as a simple way to be eventually aware of a regression.


### Other Information

The last commit is to remove warnings on compilation I have precedently introduced. Do tell me if you want it elsewhere.
