### PR TITLE
Add error handler for geos

### DIFF
--- a/doc/Factory-Compatibility.md
+++ b/doc/Factory-Compatibility.md
@@ -408,7 +408,7 @@ _Note: This list is not exhaustive of all the methods defined by each factory. T
 |                         `Collection#as_binary` |  ✅   |    ✅    |  ✅  |   ✅    |     ✅     |     ✅      |     ✅     |
 |                            `Collection#empty?` |  ✅   |    ✅    |  ✅  |   ✅    |     ✅     |     ✅      |     ✅     |
 |                           `Collection#simple?` |  ✅   |    ✅    |  ✅  |   ✅    |     ❌     |     ✅      |     ❌     |
-|                          `Collection#boundary` |  ✅   |    ❌    |  ✅  |   ❌    |     ❌     |     ✅      |     ❌     |
+|                          `Collection#boundary` |  ❌   |    ❌    |  ❌  |   ❌    |     ❌     |     ❌      |     ❌     |
 |                       `Collection#convex_hull` |  ✅   |    ✅    |  ✅  |   ✅    |     ❌     |     ✅      |     ❌     |
 |                            `Collection#buffer` |  ✅   |    ✅    |  ✅  |   ✅    |     ❌     |     ✅      |     ❌     |
 |                    `Collection#equals?(Point)` |  ✅   |    ✅    |  ✅  |   ✅    |     ❌     |     ✅      |     ❌     |

--- a/ext/geos_c_impl/analysis.c
+++ b/ext/geos_c_impl/analysis.c
@@ -37,9 +37,9 @@ VALUE rgeo_geos_analysis_ccw_p(VALUE self, VALUE ring)
   ring_data = RGEO_GEOMETRY_DATA_PTR(ring);
 
   coord_seq = GEOSGeom_getCoordSeq_r(ring_data->geos_context, ring_data->geom);
-  if (!coord_seq) { rb_raise(geos_error, "Could not retrieve CoordSeq from given ring."); }
+  if (!coord_seq) { rb_raise(rb_eGeosError, "Could not retrieve CoordSeq from given ring."); }
   if (!GEOSCoordSeq_isCCW_r(ring_data->geos_context, coord_seq, &is_ccw)) {
-    rb_raise(geos_error, "Could not determine if the CoordSeq is CCW.");
+    rb_raise(rb_eGeosError, "Could not determine if the CoordSeq is CCW.");
   }
 
   return is_ccw ? Qtrue : Qfalse;
@@ -49,8 +49,8 @@ VALUE rgeo_geos_analysis_ccw_p(VALUE self, VALUE ring)
 
 /**
  * call-seq:
- *   RGeo::Geos::Analysis.ccw_supported? -> true or false 
- * 
+ *   RGeo::Geos::Analysis.ccw_supported? -> true or false
+ *
  * Checks if the RGEO_GEOS_SUPPORTS_ISCCW macro is defined, returns +true+
  * if it is, +false+ otherwise
  */

--- a/ext/geos_c_impl/errors.c
+++ b/ext/geos_c_impl/errors.c
@@ -14,18 +14,20 @@
 
 RGEO_BEGIN_C
 
-VALUE rgeo_error;
-VALUE rgeo_invalid_geometry_error;
-VALUE geos_error;
+VALUE rb_eRGeoError;
+VALUE rb_eRGeoInvalidGeometry;
+VALUE rb_eRGeoUnsupportedOperation;
+VALUE rb_eGeosError;
 
 
 void rgeo_init_geos_errors() {
   VALUE error_module;
 
   error_module = rb_define_module_under(rgeo_module, "Error");
-  rgeo_error = rb_define_class_under(error_module, "RGeoError", rb_eRuntimeError);
-  rgeo_invalid_geometry_error = rb_define_class_under(error_module, "InvalidGeometry", rgeo_error);
-  geos_error = rb_define_class_under(error_module, "GeosError", rgeo_error);
+  rb_eRGeoError = rb_define_class_under(error_module, "RGeoError", rb_eRuntimeError);
+  rb_eRGeoInvalidGeometry = rb_define_class_under(error_module, "InvalidGeometry", rb_eRGeoError);
+  rb_eRGeoUnsupportedOperation = rb_define_class_under(error_module, "UnsupportedOperation", rb_eRGeoError);
+  rb_eGeosError = rb_define_class_under(error_module, "GeosError", rb_eRGeoError);
 }
 
 RGEO_END_C

--- a/ext/geos_c_impl/errors.h
+++ b/ext/geos_c_impl/errors.h
@@ -9,11 +9,13 @@
 RGEO_BEGIN_C
 
 // Main rgeo error type
-extern VALUE rgeo_error;
+extern VALUE rb_eRGeoError;
 // RGeo::Error::InvalidGeometry
-extern VALUE rgeo_invalid_geometry_error;
+extern VALUE rb_eRGeoInvalidGeometry;
+// RGeo::Error::UnsupportedOperation
+extern VALUE rb_eRGeoUnsupportedOperation;
 // RGeo error specific to the GEOS implementation.
-extern VALUE geos_error;
+extern VALUE rb_eGeosError;
 
 void rgeo_init_geos_errors();
 

--- a/ext/geos_c_impl/extconf.rb
+++ b/ext/geos_c_impl/extconf.rb
@@ -14,6 +14,8 @@ if RUBY_DESCRIPTION =~ /^jruby\s/
 else
   require "mkmf"
 
+  $CFLAGS << " -DRGEO_GEOS_DEBUG" if ENV.key?("DEBUG") || ENV.key?("RGEO_GEOS_DEBUG")
+
   geosconfig = with_config("geos-config") || find_executable("geos-config")
 
   if geosconfig

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -1070,7 +1070,7 @@ static VALUE method_geometry_make_valid(VALUE self)
   // According to GEOS implementation, MakeValid always returns.
   valid_geom = GEOSMakeValid_r(self_data->geos_context, self_geom);
   if (!valid_geom) {
-    rb_raise(rgeo_invalid_geometry_error, "%"PRIsVALUE, method_geometry_invalid_reason(self));
+    rb_raise(rb_eRGeoInvalidGeometry, "%"PRIsVALUE, method_geometry_invalid_reason(self));
   }
   return rgeo_wrap_geos_geometry(self_data->factory, valid_geom, Qnil);
 }
@@ -1099,7 +1099,7 @@ VALUE rgeo_geos_geometries_strict_eql(GEOSContextHandle_t context, const GEOSGeo
     return Qtrue;
   case 2:
   default:
-    rb_raise(geos_error, "Cannot test equality.");
+    rb_raise(rb_eGeosError, "Cannot test equality.");
   }
 }
 

--- a/lib/rgeo/feature/geometry.rb
+++ b/lib/rgeo/feature/geometry.rb
@@ -90,7 +90,7 @@ module RGeo
       # operations on them.)
 
       def factory
-        raise Error::UnsupportedOperation, "Method Geometry#factory not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#factory not defined."
       end
 
       # === SFS 1.1 Description
@@ -105,7 +105,7 @@ module RGeo
       # point geometries, 1 for curves, and 2 for surfaces.
 
       def dimension
-        raise Error::UnsupportedOperation, "Method Geometry#dimension not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#dimension not defined."
       end
 
       # === SFS 1.1 Description
@@ -122,7 +122,7 @@ module RGeo
       # call the +type_name+ method of the returned module.
 
       def geometry_type
-        raise Error::UnsupportedOperation, "Method Geometry#geometry_type not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#geometry_type not defined."
       end
 
       # === SFS 1.1 Description
@@ -137,7 +137,7 @@ module RGeo
       # stored in either the same or some other datastore.
 
       def srid
-        raise Error::UnsupportedOperation, "Method Geometry#srid not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#srid not defined."
       end
 
       # === SFS 1.1 Description
@@ -151,7 +151,7 @@ module RGeo
       # Returns an object that supports the Geometry interface.
 
       def envelope
-        raise Error::UnsupportedOperation, "Method Geometry#envelope not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#envelope not defined."
       end
 
       # === SFS 1.1 Description
@@ -164,7 +164,7 @@ module RGeo
       # Returns an ASCII string.
 
       def as_text
-        raise Error::UnsupportedOperation, "Method Geometry#as_text not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#as_text not defined."
       end
 
       # === SFS 1.1 Description
@@ -177,7 +177,7 @@ module RGeo
       # Returns a binary string.
 
       def as_binary
-        raise Error::UnsupportedOperation, "Method Geometry#as_binary not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#as_binary not defined."
       end
 
       # === SFS 1.1 Description
@@ -192,7 +192,7 @@ module RGeo
       # specification, which stipulates an integer return value.
 
       def empty?
-        raise Error::UnsupportedOperation, "Method Geometry#empty? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#empty? not defined."
       end
 
       def is_empty?
@@ -214,7 +214,7 @@ module RGeo
       # specification, which stipulates an integer return value.
 
       def simple?
-        raise Error::UnsupportedOperation, "Method Geometry#simple? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#simple? not defined."
       end
 
       def is_simple?
@@ -234,7 +234,7 @@ module RGeo
       # Returns an object that supports the Geometry interface.
 
       def boundary
-        raise Error::UnsupportedOperation, "Method Geometry#boundary not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#boundary not defined."
       end
 
       # === SFS 1.1 Description
@@ -253,7 +253,7 @@ module RGeo
       # from different factories is undefined.
 
       def equals?(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#equals? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#equals? not defined."
       end
 
       # === SFS 1.1 Description
@@ -272,7 +272,7 @@ module RGeo
       # from different factories is undefined.
 
       def disjoint?(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#disjoint? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#disjoint? not defined."
       end
 
       # === SFS 1.1 Description
@@ -291,7 +291,7 @@ module RGeo
       # from different factories is undefined.
 
       def intersects?(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#intersects? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#intersects? not defined."
       end
 
       # === SFS 1.1 Description
@@ -310,7 +310,7 @@ module RGeo
       # from different factories is undefined.
 
       def touches?(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#touches? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#touches? not defined."
       end
 
       # === SFS 1.1 Description
@@ -329,7 +329,7 @@ module RGeo
       # from different factories is undefined.
 
       def crosses?(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#crosses? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#crosses? not defined."
       end
 
       # === SFS 1.1 Description
@@ -348,7 +348,7 @@ module RGeo
       # from different factories is undefined.
 
       def within?(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#within? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#within? not defined."
       end
 
       # === SFS 1.1 Description
@@ -367,7 +367,7 @@ module RGeo
       # from different factories is undefined.
 
       def contains?(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#contains? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#contains? not defined."
       end
 
       # === SFS 1.1 Description
@@ -386,7 +386,7 @@ module RGeo
       # from different factories is undefined.
 
       def overlaps?(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#overlaps? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#overlaps? not defined."
       end
 
       # === SFS 1.1 Description
@@ -412,7 +412,7 @@ module RGeo
       # from different factories is undefined.
 
       def relate?(another_geometry, _intersection_pattern_matrix_)
-        raise Error::UnsupportedOperation, "Method Geometry#relate not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#relate not defined."
       end
 
       # === SFS 1.1 Description
@@ -431,7 +431,7 @@ module RGeo
       # distance between objects from different factories is undefined.
 
       def distance(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#distance not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#distance not defined."
       end
 
       # === SFS 1.1 Description
@@ -446,7 +446,7 @@ module RGeo
       # Returns an object that supports the Geometry interface.
 
       def buffer(_distance_)
-        raise Error::UnsupportedOperation, "Method Geometry#buffer not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#buffer not defined."
       end
 
       # === SFS 1.1 Description
@@ -459,7 +459,7 @@ module RGeo
       # Returns an object that supports the Geometry interface.
 
       def convex_hull
-        raise Error::UnsupportedOperation, "Method Geometry#convex_hull not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#convex_hull not defined."
       end
 
       # === SFS 1.1 Description
@@ -477,7 +477,7 @@ module RGeo
       # operations on objects from different factories is undefined.
 
       def intersection(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#intersection not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#intersection not defined."
       end
 
       # === SFS 1.1 Description
@@ -495,7 +495,7 @@ module RGeo
       # operations on objects from different factories is undefined.
 
       def union(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#union not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#union not defined."
       end
 
       # === SFS 1.1 Description
@@ -513,7 +513,7 @@ module RGeo
       # operations on objects from different factories is undefined.
 
       def difference(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#difference not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#difference not defined."
       end
 
       # === SFS 1.1 Description
@@ -531,7 +531,7 @@ module RGeo
       # operations on objects from different factories is undefined.
 
       def sym_difference(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#sym_difference not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#sym_difference not defined."
       end
 
       # Returns true if this geometric object is representationally
@@ -543,7 +543,7 @@ module RGeo
       # from different factories is undefined.
 
       def rep_equals?(another_geometry)
-        raise Error::UnsupportedOperation, "Method Geometry#rep_equals? not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#rep_equals? not defined."
       end
 
       # Unions a collection of Geometry or a single Geometry
@@ -560,7 +560,7 @@ module RGeo
       # returns nil.
       #
       def unary_union
-        raise Error::UnsupportedOperation, "Method Geometry#unary_union not defined."
+        raise Error::UnsupportedOperation, "Method #{self.class}#unary_union not defined."
       end
 
       # This method should behave almost the same as the rep_equals?

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -147,6 +147,8 @@ module RGeo
       # Only available since GEOS 3.8+
       def make_valid
         @factory.wrap_fg_geom(@fg_geom.make_valid, nil)
+      rescue ::Geos::GEOSException
+        raise Error::UnsupportedOperation
       end if ::Geos::FFIGeos.respond_to?(:GEOSMakeValid_r)
 
       def equals?(rhs)

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -97,11 +97,9 @@ module RGeo
       end
 
       def boundary
-        if self.class == FFIGeometryCollectionImpl
-          nil
-        else
-          @factory.wrap_fg_geom(@fg_geom.boundary, nil)
-        end
+        @factory.wrap_fg_geom(@fg_geom.boundary, nil)
+      rescue ::Geos::GEOSException
+        raise Error::InvalidGeometry, "Operation not supported by GeometryCollection"
       end
 
       def as_text

--- a/test/common/geometry_collection_tests.rb
+++ b/test/common/geometry_collection_tests.rb
@@ -207,7 +207,7 @@ module RGeo
 
         def test_empty_collection_boundary
           empty = @factory.collection([])
-          assert_nil(empty.boundary)
+          assert_raises(RGeo::Error::InvalidGeometry) { empty.boundary }
         end
 
         def test_each_block

--- a/test/common/validity_tests.rb
+++ b/test/common/validity_tests.rb
@@ -53,7 +53,7 @@ module RGeo
           skip "#make_valid not handled by current implementation" unless implements_make_valid?
 
           assert_equal(bowtie_polygon_expected_area, bowtie_polygon.make_valid.area)
-          assert_raises(RGeo::Error::InvalidGeometry) do
+          assert_raises(RGeo::Error::UnsupportedOperation) do
             # A self intersecting ring cannot be made valid.
             bowtie_polygon.exterior_ring.make_valid
           end

--- a/test/geos_capi/analysis_test.rb
+++ b/test/geos_capi/analysis_test.rb
@@ -23,7 +23,7 @@ module GeosCapi
       skip "Needs GEOS 3.7+" unless RGeo::Geos::Analysis.ccw_supported?
       factory = RGeo::Geos.factory(native_interface: :capi)
       point = factory.point(1, 2)
-      assert_raises(RGeo::Error::GeosError) { RGeo::Geos::Analysis.ccw?(point) }
+      assert_raises(RGeo::Error::InvalidGeometry) { RGeo::Geos::Analysis.ccw?(point) }
     end
 
     def test_ccw_p_returns_true_if_ccw

--- a/test/geos_capi/line_string_test.rb
+++ b/test/geos_capi/line_string_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "../test_helper"
 
 class GeosLineStringTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::LineStringTests


### PR DESCRIPTION
### Summary

When coding for the validity handling we noticed that there were still some places where we return `nil` rather than raising for invalidity or unsupported operations. This PR fixes it.

### TODO

Tests are not yet passing, there are some errors here that should be categorised correctly. On the notice handler part, when running tests with `DEBUG=1 rake` we can see that there are a lot of warnings, surely something to handle
