### PR TITLE
Fix Psych::DisallowedClass errors in tests for ruby 3.1 / head

### DIFF
--- a/rgeo.gemspec
+++ b/rgeo.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "ffi-geos", "~> 1.2"
   spec.add_development_dependency "minitest", "~> 5.11"
+  spec.add_development_dependency "psych", ">= 4.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-compiler", "~> 1.0"
   spec.add_development_dependency "rubocop", "~> 1.8.1"

--- a/test/common/factory_tests.rb
+++ b/test/common/factory_tests.rb
@@ -64,7 +64,7 @@ module RGeo
 
         def test_psych_dump_load_factory
           data = Psych.dump(@factory)
-          factory2 = Psych.load(data)
+          factory2 = Psych.unsafe_load(data)
           assert_equal(@factory, factory2)
           assert_equal(srid, factory2.srid)
         end

--- a/test/common/line_string_tests.rb
+++ b/test/common/line_string_tests.rb
@@ -320,7 +320,7 @@ module RGeo
           point2 = @factory.point(0, 1)
           line1 = @factory.line_string([point1, point2])
           data = Psych.dump(line1)
-          line2 = Psych.load(data)
+          line2 = Psych.unsafe_load(data)
           assert_equal(line1, line2)
         end
 

--- a/test/common/point_tests.rb
+++ b/test/common/point_tests.rb
@@ -341,21 +341,21 @@ module RGeo
         def test_psych_roundtrip
           point = @factory.point(11, 12)
           data = Psych.dump(point)
-          point2 = Psych.load(data)
+          point2 = Psych.unsafe_load(data)
           assert_equal(point, point2)
         end
 
         def test_psych_roundtrip_3d
           point = @zfactory.point(11, 12, 13)
           data = Psych.dump(point)
-          point2 = Psych.load(data)
+          point2 = Psych.unsafe_load(data)
           assert_equal(point, point2)
         end
 
         def test_psych_roundtrip_4d
           point = @zmfactory.point(11, 12, 13, 14)
           data = Psych.dump(point)
-          point2 = Psych.load(data)
+          point2 = Psych.unsafe_load(data)
           assert_equal(point, point2)
         end
 

--- a/test/coord_sys/ogc_cs_test.rb
+++ b/test/coord_sys/ogc_cs_test.rb
@@ -327,7 +327,7 @@ class OgcCsTest < Minitest::Test # :nodoc:
     input = 'COMPD_CS["OSGB36 / British National Grid + ODN",PROJCS["OSGB 1936 / British National Grid",GEOGCS["OSGB 1936",DATUM["OSGB 1936",SPHEROID["Airy 1830",6377563.396,299.3249646,AUTHORITY["EPSG","7001"]],TOWGS84[446.448,-125.157,542.06,0.15,0.247,0.842,-4.2261596151967575],AUTHORITY["EPSG","6277"]],PRIMEM["Greenwich",0.0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.017453292519943295],AXIS["Geodetic latitude",NORTH],AXIS["Geodetic longitude",EAST],AUTHORITY["EPSG","4277"]],PROJECTION["Transverse Mercator",AUTHORITY["EPSG","9807"]],PARAMETER["central_meridian",-2.0],PARAMETER["latitude_of_origin",49.0],PARAMETER["scale_factor",0.9996012717],PARAMETER["false_easting",400000.0],PARAMETER["false_northing",-100000.0],UNIT["m",1.0],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","27700"]],VERT_CS["Newlyn",VERT_DATUM["Ordnance Datum Newlyn",2005,AUTHORITY["EPSG","5101"]],UNIT["m",1.0],AXIS["Gravity-related height",UP],AUTHORITY["EPSG","5701"]],AUTHORITY["EPSG","7405"]]'
     obj1 = RGeo::CoordSys::CS.create_from_wkt(input)
     dump = Psych.dump(obj1)
-    obj2 = Psych.load(dump)
+    obj2 = Psych.unsafe_load(dump)
     assert_equal(obj1, obj2)
   end
 


### PR DESCRIPTION
Thanks for merging my previous PR so swiftly!  

I noticed some failures on the latest version of ruby in CI because of a Psych::DisallowedClass error. This is because Psych 4.0 aliases `load` to `safe_load`. (Related release notes: https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/)

Using `unsafe_load` and ensuring that the latest version of [Psych](https://github.com/ruby/psych) is used, regardless of the ruby version, fixes this. (I believe the Psych version works with all the tested ruby versions.)



