### PR TITLE
Support GEOS Installation from Library

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task :clean do
   clean_files = %w[pkg tmp] +
     Dir.glob("ext/**/Makefile*") +
     Dir.glob("ext/**/*.{o,class,log,dSYM}") +
-    Dir.glob("**/*.{bundle,so,dll,rbc,jar}") +
+    Dir.glob("{ext,tmp,lib}/**/*.{bundle,so,dll,rbc,jar}")
     Dir.glob("**/.rbx")
 
   clean_files.each { |path| rm_rf path }

--- a/ext/geos_c_impl/extconf.rb
+++ b/ext/geos_c_impl/extconf.rb
@@ -6,14 +6,40 @@
 #
 # -----------------------------------------------------------------------------
 def create_dummy_makefile
-  File.open("Makefile", "w") { |f_| f_.write(".PHONY: install\ninstall:\n") }
+  File.write("Makefile", ".PHONY: install\ninstall:\n")
 end
 
-if RUBY_DESCRIPTION =~ /^jruby\s/
-  create_dummy_makefile
-else
-  require "mkmf"
+def build_from_library(lib_dir)
+  # ensure lib_dir has priority over system directories
+  $LIBPATH = [lib_dir]
 
+  # NOTE: due to how find_library works, if lib_dir does not contain the library
+  # and you have libgeos installed on your system, it will silently use the system libgeos.
+  found_geos = false
+  if find_library("geos_c", nil, lib_dir)
+    # add macro manually
+    $defs << "-DHAVE_GEOS_C_H"
+    found_geos = true if have_func("GEOSSetSRID_r")
+
+    have_func("GEOSPreparedContains_r")
+    have_func("GEOSPreparedDisjoint_r")
+    have_func("GEOSUnaryUnion_r")
+    have_func("GEOSCoordSeq_isCCW_r")
+    have_func("rb_memhash", "ruby.h")
+  end
+
+  if found_geos
+    create_makefile("rgeo/geos/geos_c_impl")
+  else
+    puts "**** WARNING: Unable to find GEOS library from the specified path."
+    puts "**** Ensure that the libgeos_c is in the directory you specified."
+    puts "**** Compiling without GEOS support."
+
+    create_dummy_makefile
+  end
+end
+
+def build_from_geos_config
   geosconfig = with_config("geos-config") || find_executable("geos-config")
 
   if geosconfig
@@ -25,9 +51,9 @@ else
     end
   end
 
-  found_geos_ = false
+  found_geos = false
   if have_header("geos_c.h")
-    found_geos_ = true if have_func("GEOSSetSRID_r", "geos_c.h")
+    found_geos = true if have_func("GEOSSetSRID_r", "geos_c.h")
     have_func("GEOSPreparedContains_r", "geos_c.h")
     have_func("GEOSPreparedDisjoint_r", "geos_c.h")
     have_func("GEOSUnaryUnion_r", "geos_c.h")
@@ -35,7 +61,7 @@ else
     have_func("rb_memhash", "ruby.h")
   end
 
-  if found_geos_
+  if found_geos
     create_makefile("rgeo/geos/geos_c_impl")
   else
     puts "**** WARNING: Unable to find GEOS headers or libraries."
@@ -44,4 +70,14 @@ else
 
     create_dummy_makefile
   end
+end
+
+if RUBY_DESCRIPTION =~ /^jruby\s/
+  create_dummy_makefile
+elsif ENV["RGEO_GEOS_LIB_DIR"]
+  require "mkmf"
+  build_from_library(ENV["RGEO_GEOS_LIB_DIR"])
+else
+  require "mkmf"
+  build_from_geos_config
 end


### PR DESCRIPTION
### Summary

Allows GEOS to be linked with a library (.so, .a, .dll, etc.) by specifying the `RGEO_GEOS_LIB_DIR` environment variable. 

### Other Information

This works, but there are still a couple issues that need to be discussed/resolved

- [ ] Due to how `find_library` works if `libgeos_c` is not found in the `RGEO_GEOS_LIB_DIR` directory and it is installed on the system (`/usr/local/lib` for example), it will silently fall back on the system installed version instead of raising an error.
- [ ] We may want to discuss automatically falling back on the `geos-config` flow if there is an error during the from library flow.

