### PR TITLE
Only require geos/ffi_* if FFI supported

### DIFF
--- a/History.md
+++ b/History.md
@@ -24,6 +24,7 @@
 **Bug Fixes**
 
 * Fix CAPI equality (`==`) comparison on macos by using `GEOSEqualsExact_r` #270
+* Only require geos/ffi_* if FFI supported #297
 
 ### 2.4.0 / 2022-01-19
 

--- a/lib/rgeo/geos.rb
+++ b/lib/rgeo/geos.rb
@@ -33,9 +33,6 @@ module RGeo
       require_relative "geos/capi_feature_classes"
       require_relative "geos/capi_factory"
     end
-    require_relative "geos/ffi_feature_methods"
-    require_relative "geos/ffi_feature_classes"
-    require_relative "geos/ffi_factory"
     require_relative "geos/zm_feature_methods"
     require_relative "geos/zm_feature_classes"
     require_relative "geos/zm_factory"
@@ -54,6 +51,12 @@ module RGeo
     rescue StandardError => ex
       FFI_SUPPORTED = false
       FFI_SUPPORT_EXCEPTION = ex
+    end
+
+    if FFI_SUPPORTED
+      require_relative "geos/ffi_feature_methods"
+      require_relative "geos/ffi_feature_classes"
+      require_relative "geos/ffi_factory"
     end
 
     # Default preferred native interface


### PR DESCRIPTION
### Summary

https://github.com/rgeo/rgeo/pull/275 introduced a hard dependency on `ffi-geos`: https://github.com/rgeo/rgeo/blob/fb0bfcdd0c3a1fdd67ab3f0ccff9cccb68d50336/lib/rgeo/geos/ffi_feature_methods.rb#L9

I suspect this was unintentional, since there is an alternative CAPI interface to GEOS that can be used without `ffi-geos`, and `ffi-geos` is not listed as a dependency in the gemspec.

This pull request adds a conditional to only require geos/ffi_* if `ffi-geos` is installed. This allows RGeo to be used without `ffi-geos`.

### Other Information

Thanks for all your hard work on v3! It's great work, much appreciated.