### PR TITLE
Add ruby_memcheck and fix leaks!

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "pry-byebug" if ENV["BYEBUG"]

--- a/History.md
+++ b/History.md
@@ -1,3 +1,13 @@
+### Current
+
+**Minor Changes**
+
+* Implement `coordinate_dimension`, `spatial_dimension`, `is_3d?` and `measured?` for all factories.
+
+**Bug Fixes**
+
+* Fix memory leak on failing geometry collection creation #301
+
 ### 3.0.0-rc.1 / 2022-03-22
 
 **Breaking Changes**
@@ -21,7 +31,6 @@
 * Add `PlanarGraph` class to cartesian library
 * Change `validate_geometry` methods to `init_geometry` methods that handle only quality of life functionality instead of validation as well
 * Add OGC SFS 1.2 methods to `RGeo::Feature::Geometry`.
-* Implement `coordinate_dimension`, `spatial_dimension`, `is_3d?` and `measured?` for all factories.
 
 **Bug Fixes**
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,11 @@
 
 require "rake/testtask"
 require "rake/extensiontask"
+require "ruby_memcheck"
 require "bundler/gem_tasks"
 require "yard"
+
+RubyMemcheck.config(binary_name: "geos_c_impl")
 
 # Build tasks
 
@@ -25,10 +28,16 @@ task :clean do
   clean_files.each { |path| rm_rf path }
 end
 
-Rake::TestTask.new(:test) do |t|
+test_config = proc do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
+end
+
+Rake::TestTask.new(:test, &test_config)
+
+namespace :test do
+  RubyMemcheck::TestTask.new(valgrind: :compile, &test_config)
 end
 
 YARD::Rake::YardocTask.new do |t|

--- a/bin/console
+++ b/bin/console
@@ -5,6 +5,7 @@
 $LOAD_PATH.prepend File.join __dir__, "..", "lib"
 
 require "rgeo"
+require "irb"
 
 $factory = $f = RGeo::Cartesian.factory
 

--- a/ext/geos_c_impl/factory.c
+++ b/ext/geos_c_impl/factory.c
@@ -110,7 +110,7 @@ static void destroy_factory_func(void* data)
     GEOSWKBWriter_destroy_r(context, factory_data->marshal_wkb_writer);
   }
   finishGEOS_r(context);
-  free(factory_data);
+  FREE(factory_data);
 }
 
 
@@ -132,7 +132,7 @@ static void destroy_geometry_func(void* data)
   {
     GEOSPreparedGeom_destroy_r(geometry_data->geos_context, prep);
   }
-  free(geometry_data);
+  FREE(geometry_data);
 }
 
 
@@ -546,7 +546,7 @@ static VALUE cmethod_factory_create(VALUE klass, VALUE flags, VALUE srid, VALUE 
       result = TypedData_Wrap_Struct(klass, &rgeo_factory_type, data);
     }
     else {
-      free(data);
+      FREE(data);
     }
   }
   return result;

--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -167,8 +167,15 @@ const GEOSGeometry* rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALU
   result of this function to build a GEOS-backed clone of the original
   geometry, or to include the given geometry in a collection while keeping
   the klasses intact.
+
+  The state parameter is given to follow `rb_protect*` ruby methods: this
+  method calls `#cast`, and this call may raise. if it does raise, state
+  will be set to a non-zero value, and you'll have access to the error
+  in `rb_errinfo()`. IT IS THE CALLER'S RESPONSIBILITY TO PROPAGATE THE
+  ERROR. You could also discard the error with `rb_set_errinfo(Qnil)`,
+  this will just ignore the error altogether.
 */
-GEOSGeometry* rgeo_convert_to_detached_geos_geometry(VALUE obj, VALUE factory, VALUE type, VALUE* klasses);
+GEOSGeometry* rgeo_convert_to_detached_geos_geometry(VALUE obj, VALUE factory, VALUE type, VALUE* klasses, int* state);
 
 /*
   Returns 1 if the given ruby object is a GEOS Geometry implementation,

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -10,16 +10,16 @@
 #include <ruby.h>
 #include <geos_c.h>
 
-#include "globals.h"
-
-#include "factory.h"
-#include "geometry.h"
-#include "line_string.h"
-#include "polygon.h"
-#include "geometry.h"
-#include "geometry_collection.h"
 
 #include "coordinates.h"
+#include "errors.h"
+#include "factory.h"
+#include "geometry.h"
+#include "geometry_collection.h"
+#include "globals.h"
+#include "line_string.h"
+#include "polygon.h"
+
 
 RGEO_BEGIN_C
 
@@ -44,17 +44,19 @@ static VALUE create_geometry_collection(VALUE module, int type, VALUE factory, V
   VALUE cast_type;
   GEOSGeometry* geom;
   GEOSGeometry* collection;
+  int state = 0;
 
   result = Qnil;
   Check_Type(array, T_ARRAY);
   len = (unsigned int)RARRAY_LEN(array);
   geoms = ALLOC_N(GEOSGeometry*, len == 0 ? 1 : len);
-  if (geoms) {
-    factory_data = RGEO_FACTORY_DATA_PTR(factory);
-    geos_context = factory_data->geos_context;
-    klasses = Qnil;
-    cast_type = Qnil;
-    switch (type) {
+  if (!geoms) { rb_raise(rb_eRGeoError, "not enough memory available"); }
+
+  factory_data = RGEO_FACTORY_DATA_PTR(factory);
+  geos_context = factory_data->geos_context;
+  klasses = Qnil;
+  cast_type = Qnil;
+  switch (type) {
     case GEOS_MULTIPOINT:
       cast_type = rgeo_feature_point_module;
       break;
@@ -64,45 +66,46 @@ static VALUE create_geometry_collection(VALUE module, int type, VALUE factory, V
     case GEOS_MULTIPOLYGON:
       cast_type = rgeo_feature_polygon_module;
       break;
+  }
+  for (i=0; i<len; ++i) {
+    geom = rgeo_convert_to_detached_geos_geometry(rb_ary_entry(array, i), factory, cast_type, &klass, &state);
+    if (state || !geom) {
+      break;
     }
-    for (i=0; i<len; ++i) {
-      geom = rgeo_convert_to_detached_geos_geometry(rb_ary_entry(array, i), factory, cast_type, &klass);
-      if (!geom) {
-        break;
-      }
-      geoms[i] = geom;
-      if (!NIL_P(klass) && NIL_P(klasses)) {
-        klasses = rb_ary_new2(len);
-        for (j=0; j<i; ++j) {
-          rb_ary_push(klasses, Qnil);
-        }
-      }
-      if (!NIL_P(klasses)) {
-        rb_ary_push(klasses, klass);
-      }
-    }
-    if (i != len) {
+    geoms[i] = geom;
+    if (!NIL_P(klass) && NIL_P(klasses)) {
+      klasses = rb_ary_new2(len);
       for (j=0; j<i; ++j) {
-        GEOSGeom_destroy_r(geos_context, geoms[j]);
+        rb_ary_push(klasses, Qnil);
       }
     }
-    else {
-      collection = GEOSGeom_createCollection_r(geos_context, type, geoms, len);
-      if (collection) {
-        result = rgeo_wrap_geos_geometry(factory, collection, module);
-        RGEO_GEOMETRY_DATA_PTR(result)->klasses = klasses;
-      }
-      // NOTE: We are assuming that GEOS will do its own cleanup of the
-      // element geometries if it fails to create the collection, so we
-      // are not doing that ourselves. If that turns out not to be the
-      // case, this will be a memory leak.
+    if (!NIL_P(klasses)) {
+      rb_ary_push(klasses, klass);
     }
-    FREE(geoms);
+  }
+  if (i != len) {
+    for (j=0; j<i; ++j) {
+      GEOSGeom_destroy_r(geos_context, geoms[j]);
+    }
+  }
+  else {
+    collection = GEOSGeom_createCollection_r(geos_context, type, geoms, len);
+    if (collection) {
+      result = rgeo_wrap_geos_geometry(factory, collection, module);
+      RGEO_GEOMETRY_DATA_PTR(result)->klasses = klasses;
+    }
+    // NOTE: We are assuming that GEOS will do its own cleanup of the
+    // element geometries if it fails to create the collection, so we
+    // are not doing that ourselves. If that turns out not to be the
+    // case, this will be a memory leak.
+  }
+  FREE(geoms);
+  if (state) {
+    rb_exc_raise(rb_errinfo()); // raise $!
   }
 
   return result;
 }
-
 
 /**** RUBY METHOD DEFINITIONS ****/
 

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -97,7 +97,7 @@ static VALUE create_geometry_collection(VALUE module, int type, VALUE factory, V
       // are not doing that ourselves. If that turns out not to be the
       // case, this will be a memory leak.
     }
-    free(geoms);
+    FREE(geoms);
   }
 
   return result;

--- a/ext/geos_c_impl/line_string.c
+++ b/ext/geos_c_impl/line_string.c
@@ -447,7 +447,7 @@ static GEOSCoordSequence* coord_seq_from_array(VALUE factory, VALUE array, char 
       }
     }
     if (!good) {
-      free(coords);
+      FREE(coords);
       return NULL;
     }
   }
@@ -472,7 +472,7 @@ static GEOSCoordSequence* coord_seq_from_array(VALUE factory, VALUE array, char 
       GEOSCoordSeq_setZ_r(context, coord_seq, len, has_z ? coords[2] : 0);
     }
   }
-  free(coords);
+  FREE(coords);
   return coord_seq;
 }
 

--- a/ext/geos_c_impl/main.c
+++ b/ext/geos_c_impl/main.c
@@ -9,8 +9,8 @@
 #include <ruby.h>
 #include <geos_c.h>
 
+#include "ruby_more.h"
 #include "globals.h"
-
 #include "errors.h"
 
 #include "factory.h"

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -261,14 +261,14 @@ static VALUE cmethod_create(VALUE module, VALUE factory, VALUE exterior, VALUE i
       if (len == actual_len) {
         polygon = GEOSGeom_createPolygon_r(context, exterior_geom, interior_geoms, actual_len);
         if (polygon) {
-          free(interior_geoms);
+          FREE(interior_geoms);
           return rgeo_wrap_geos_geometry(factory, polygon, rgeo_geos_polygon_class);
         }
       }
       for (i=0; i<actual_len; ++i) {
         GEOSGeom_destroy_r(context, interior_geoms[i]);
       }
-      free(interior_geoms);
+      FREE(interior_geoms);
     }
     GEOSGeom_destroy_r(context, exterior_geom);
   }

--- a/ext/geos_c_impl/preface.h
+++ b/ext/geos_c_impl/preface.h
@@ -50,3 +50,7 @@
 
 // https://ozlabs.org/~rusty/index.cgi/tech/2008-04-01.html
 #define streq(a, b) (!strcmp((a),(b)))
+
+// When using ruby ALLOC* macros, we are using ruby_xmalloc, which counterpart
+// is ruby_xfree. This macro helps enforcing that by showing us the way.
+#define FREE ruby_xfree

--- a/ext/geos_c_impl/ruby_more.c
+++ b/ext/geos_c_impl/ruby_more.c
@@ -1,0 +1,65 @@
+/*
+	Utilities for the ruby CAPI
+*/
+
+#ifndef RGEO_GEOS_RUBY_MORE_INCLUDED
+#define RGEO_GEOS_RUBY_MORE_INCLUDED
+
+#include <ruby.h>
+
+#include "preface.h"
+#include "ruby_more.h"
+
+RGEO_BEGIN_C
+
+struct funcall_args
+{
+	VALUE recv;
+	ID mid;
+	int argc;
+	VALUE *argv;
+};
+
+static VALUE inner_funcall(VALUE args_)
+{
+	struct funcall_args *args = (struct funcall_args *)args_;
+	return rb_funcallv(
+		args->recv,
+		args->mid,
+		args->argc,
+		args->argv);
+}
+
+VALUE rb_protect_funcall(VALUE recv, ID mid, int *state, int n, ...)
+{
+	struct funcall_args args;
+	VALUE *argv;
+	va_list ar;
+
+	if (n > 0)
+	{
+		long i;
+		va_start(ar, n);
+		argv = ALLOCA_N(VALUE, n);
+		for (i = 0; i < n; i++)
+		{
+			argv[i] = va_arg(ar, VALUE);
+		}
+		va_end(ar);
+	}
+	else
+	{
+		argv = 0;
+	}
+
+	args.recv = recv;
+	args.mid = mid;
+	args.argc = n;
+	args.argv = argv;
+
+	return rb_protect(inner_funcall, (VALUE)&args, state);
+}
+
+RGEO_END_C
+
+#endif

--- a/ext/geos_c_impl/ruby_more.h
+++ b/ext/geos_c_impl/ruby_more.h
@@ -1,0 +1,16 @@
+/*
+	Utilities for the ruby CAPI
+*/
+
+#ifndef RGEO_GEOS_RUBY_MORE_INCLUDED
+#define RGEO_GEOS_RUBY_MORE_INCLUDED
+
+#include <ruby.h>
+
+RGEO_BEGIN_C
+
+VALUE rb_protect_funcall(VALUE recv, ID mid, int *state, int n, ...);
+
+RGEO_END_C
+
+#endif

--- a/rgeo.gemspec
+++ b/rgeo.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-compiler", "~> 1.0"
   spec.add_development_dependency "rubocop", "~> 1.8.1"
+  spec.add_development_dependency "ruby_memcheck", "~> 1.0"
   spec.add_development_dependency "yard", "~> 0.9"
 end

--- a/test/cartesian_bbox_test.rb
+++ b/test/cartesian_bbox_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "test_helper"
 
 class CartesianBBoxTest < Minitest::Test # :nodoc:
   def setup

--- a/test/geos_capi/geometry_collection_test.rb
+++ b/test/geos_capi/geometry_collection_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "../test_helper"
 
 class GeosGeometryCollectionTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::GeometryCollectionTests

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Ensure that we cleanup every object before comparing with valgrind.
+at_exit { GC.start } if ENV["LD_PRELOAD"]&.include? "valgrind"
+
 require "minitest/autorun"
 require_relative "../lib/rgeo"
 require "psych"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,8 +24,6 @@ require_relative "common/point_tests"
 require_relative "common/polygon_tests"
 require_relative "common/validity_tests"
 
-require "pry-byebug" if ENV["BYEBUG"]
-
 # Static test for missed references in our CAPI codebase (or FFI interface).
 # See https://alanwu.space/post/check-compaction/
 if defined?(GC.verify_compaction_references) == "method"

--- a/test/wkrep/wkb_generator_test.rb
+++ b/test/wkrep/wkb_generator_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "../test_helper"
 
 class WKBGeneratorTest < Minitest::Test # :nodoc:
   def setup


### PR DESCRIPTION
## Summary

The [ruby_memcheck](https://github.com/Shopify/ruby_memcheck) gem provides a hook to valgrind for someone who would like to check his library against valgrind memcheck. I've added it to rgeo, and fixed some memory leaks, thanks to @peterzhu2118 for his help and the gem!

There are two main fixes

1. use `ruby_xfree` against ruby allocator, rather than free, those may not be the same malloc/free (and not compatible).
2. fix a memory leak involving `#cast` ruby calls from the CAPI. See commit message for details.

## What's next

I'll open another PR that integrates memcheck to the CI, this is not that easy to integrate properly for now since there is no clear way to output potential errors, or filter out false positives. Will do so :)

## Mac users

If you are like me running on mac, and still want to use valgrind, here's the Dockerfile I used:

```dockerfile
FROM ruby:3.0

ARG work_dir=/ bundle_dir=/usr/local/bundle # if you want to mimic you PWD and .bundle

WORKDIR ${work_dir}
RUN bundle config set --local path ${bundle_dir}

RUN apt update && apt install -y libgeos-dev valgrind

COPY Gemfile rgeo.gemspec ./
COPY lib/rgeo/version.rb ./lib/rgeo/
RUN bundle install

COPY . .
RUN rake compile


CMD ["rake", "test:valgrind"]
```