### PR TITLE
Add New OGC SFS 1.2 Methods

### DIFF
--- a/History.md
+++ b/History.md
@@ -20,6 +20,8 @@
 * Add `SweeplineIntersector` class to cartesian library
 * Add `PlanarGraph` class to cartesian library
 * Change `validate_geometry` methods to `init_geometry` methods that handle only quality of life functionality instead of validation as well
+* Add OGC SFS 1.2 methods to `RGeo::Feature::Geometry`.
+* Implement `coordinate_dimension`, `spatial_dimension`, `is_3d?` and `measured?` for all factories.
 
 **Bug Fixes**
 

--- a/lib/rgeo/cartesian/factory.rb
+++ b/lib/rgeo/cartesian/factory.rb
@@ -22,6 +22,11 @@ module RGeo
       def initialize(opts = {})
         @has_z = opts[:has_z_coordinate] ? true : false
         @has_m = opts[:has_m_coordinate] ? true : false
+        @coordinate_dimension = 2
+        @coordinate_dimension += 1 if @has_z
+        @coordinate_dimension += 1 if @has_m
+        @spatial_dimension = @has_z ? 3 : 2
+
         @proj4 = opts[:proj4]
         if @proj4 && CoordSys.check!(:proj4)
           if @proj4.is_a?(String) || @proj4.is_a?(Hash)
@@ -74,6 +79,7 @@ module RGeo
           @wkb_parser = WKRep::WKBParser.new(self)
         end
       end
+      attr_reader :coordinate_dimension, :spatial_dimension
 
       # Equivalence test.
 

--- a/lib/rgeo/cartesian/feature_methods.rb
+++ b/lib/rgeo/cartesian/feature_methods.rb
@@ -17,6 +17,22 @@ module RGeo
         BoundingBox.new(factory).add(self).to_geometry
       end
 
+      def coordinate_dimension
+        factory.coordinate_dimension
+      end
+
+      def spatial_dimension
+        factory.spatial_dimension
+      end
+
+      def is_3d?
+        factory.property(:has_z_coordinate)
+      end
+
+      def measured?
+        factory.property(:has_m_coordinate)
+      end
+
       private
 
       def graph

--- a/lib/rgeo/feature/geometry.rb
+++ b/lib/rgeo/feature/geometry.rb
@@ -108,6 +108,36 @@ module RGeo
         raise Error::UnsupportedOperation, "Method #{self.class}#dimension not defined."
       end
 
+      # === SFS 1.2 Description
+      #
+      # The coordinate dimension is the dimension of direct positions (coordinate tuples) used in
+      # the definition of this geometric object
+      #
+      # === Notes
+      #
+      # Difference between this and dimension is that this is the dimension of the coordinate
+      # not the dimension of the geometry.
+      #
+      # @return [Integer]
+      def coordinate_dimension
+        raise Error::UnsupportedOperation, "Method #{self.class}#coordinate_dimension not defined."
+      end
+
+      # === SFS 1.2 Description
+      #
+      # The spatial dimension is the dimension of the spatial portion of the direct positions
+      # (coordinate tuples) used in the definition of this geometric object. If the direct positions
+      # do not carry a measure coordinate, this will be equal to the coordinate dimension.
+      #
+      # === Notes
+      #
+      # Similar to coordinate_dimension except it will ignore the M component always.
+      #
+      # @return [Integer]
+      def spatial_dimension
+        raise Error::UnsupportedOperation, "Method #{self.class}#spatial_dimension not defined."
+      end
+
       # === SFS 1.1 Description
       #
       # Returns the instantiable subtype of Geometry of which this
@@ -220,6 +250,28 @@ module RGeo
       def is_simple?
         warn "The is_simple? method is deprecated, please use the simple? counterpart, will be removed in v3" unless ENV["RGEO_SILENCE_DEPRECATION"]
         simple?
+      end
+
+      # === SFS 1.2 Description
+      #
+      # Returns 1 (TRUE) if this geometric object has z coordinate values.
+      #
+      # === Notes
+      #
+      # @return [Boolean]
+      def is_3d?
+        raise Error::UnsupportedOperation, "Method #{self.class}#is_3d? not defined."
+      end
+
+      # === SFS 1.2 Description
+      #
+      # Returns 1 (TRUE) if this geometric object has m coordinate values.
+      #
+      # === Notes
+      #
+      # @return [Boolean]
+      def measured?
+        raise Error::UnsupportedOperation, "Method #{self.class}#measured? not defined."
       end
 
       # === SFS 1.1 Description
@@ -413,6 +465,33 @@ module RGeo
 
       def relate?(another_geometry, _intersection_pattern_matrix_)
         raise Error::UnsupportedOperation, "Method #{self.class}#relate not defined."
+      end
+
+      # === SFS 1.2 Description
+      #
+      # Returns a derived geometry collection value that matches the
+      # specified m coordinate value.
+      #
+      # === Notes
+      #
+      # @param m_value [Float] value to find matches for
+      # @return [RGeo::Feature::GeometryCollection]
+      def locate_along
+        raise Error::UnsupportedOperation, "Method #{self.class}#locate_along not defined."
+      end
+
+      # === SFS 1.2 Description
+      #
+      # Returns a derived geometry collection value
+      # that matches the specified range of m coordinate values inclusively
+      #
+      # === Notes
+      #
+      # @param m_start [Float] lower bound of value range
+      # @param m_end [Float] upper bound of value range
+      # @return [RGeo::Feature::GeometryCollection]
+      def locate_between
+        raise Error::UnsupportedOperation, "Method #{self.class}#locate_between not defined."
       end
 
       # === SFS 1.1 Description

--- a/lib/rgeo/geographic/factory.rb
+++ b/lib/rgeo/geographic/factory.rb
@@ -31,6 +31,11 @@ module RGeo
         @multi_polygon_class = Geographic.const_get("#{impl_prefix}MultiPolygonImpl")
         @support_z = opts[:has_z_coordinate] ? true : false
         @support_m = opts[:has_m_coordinate] ? true : false
+        @coordinate_dimension = 2
+        @coordinate_dimension += 1 if @support_z
+        @coordinate_dimension += 1 if @support_m
+        @spatial_dimension = @support_z ? 3 : 2
+
         @srid = (opts[:srid] || 4326).to_i
         @proj4 = opts[:proj4]
         if @proj4 && CoordSys.check!(:proj4)
@@ -75,6 +80,7 @@ module RGeo
         end
         @projector = nil
       end
+      attr_reader :coordinate_dimension, :spatial_dimension
 
       # Equivalence test.
 

--- a/lib/rgeo/geographic/projected_feature_methods.rb
+++ b/lib/rgeo/geographic/projected_feature_methods.rb
@@ -22,6 +22,22 @@ module RGeo
         factory.unproject(projection.unsafe_envelope)
       end
 
+      def coordinate_dimension
+        factory.coordinate_dimension
+      end
+
+      def spatial_dimension
+        factory.spatial_dimension
+      end
+
+      def is_3d?
+        factory.property(:has_z_coordinate)
+      end
+
+      def measured?
+        factory.property(:has_m_coordinate)
+      end
+
       def empty?
         projection.empty?
       end

--- a/lib/rgeo/geographic/spherical_feature_methods.rb
+++ b/lib/rgeo/geographic/spherical_feature_methods.rb
@@ -12,6 +12,22 @@ module RGeo
       def srid
         factory.srid
       end
+
+      def coordinate_dimension
+        factory.coordinate_dimension
+      end
+
+      def spatial_dimension
+        factory.spatial_dimension
+      end
+
+      def is_3d?
+        factory.property(:has_z_coordinate)
+      end
+
+      def measured?
+        factory.property(:has_m_coordinate)
+      end
     end
 
     module SphericalPointMethods # :nodoc:

--- a/lib/rgeo/geos/capi_feature_classes.rb
+++ b/lib/rgeo/geos/capi_feature_classes.rb
@@ -13,6 +13,17 @@ module RGeo
     module CAPIGeometryMethods
       include Feature::Instance
 
+      def coordinate_dimension
+        dim = 2
+        dim += 1 if factory.supports_z?
+        dim += 1 if factory.supports_m?
+        dim
+      end
+
+      def spatial_dimension
+        factory.supports_z? ? 3 : 2
+      end
+
       def is_empty? # rubocop:disable Naming/PredicateName
         warn "The is_empty? method is deprecated, please use the empty? counterpart, will be removed in v3" unless ENV["RGEO_SILENCE_DEPRECATION"]
         empty?
@@ -21,6 +32,14 @@ module RGeo
       def is_simple? # rubocop:disable Naming/PredicateName
         warn "The is_simple? method is deprecated, please use the simple? counterpart, will be removed in v3" unless ENV["RGEO_SILENCE_DEPRECATION"]
         simple?
+      end
+
+      def is_3d?
+        factory.supports_z?
+      end
+
+      def measured?
+        factory.supports_m?
       end
 
       def inspect

--- a/lib/rgeo/geos/ffi_factory.rb
+++ b/lib/rgeo/geos/ffi_factory.rb
@@ -25,6 +25,11 @@ module RGeo
         if @has_z && @has_m
           raise Error::UnsupportedOperation, "GEOS cannot support both Z and M coordinates at the same time."
         end
+        @coordinate_dimension = 2
+        @coordinate_dimension += 1 if @has_z
+        @coordinate_dimension += 1 if @has_m
+        @spatial_dimension = @has_z ? 3 : 2
+
         @_has_3d = @has_z || @has_m
         @buffer_resolution = opts[:buffer_resolution].to_i
         @buffer_resolution = 1 if @buffer_resolution < 1
@@ -106,6 +111,7 @@ module RGeo
           @wkb_reader = nil
         end
       end
+      attr_reader :coordinate_dimension, :spatial_dimension
 
       # Standard object inspection output
 

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -77,6 +77,14 @@ module RGeo
         Utils.ffi_compute_dimension(@fg_geom)
       end
 
+      def coordinate_dimension
+        factory.coordinate_dimension
+      end
+
+      def spatial_dimension
+        factory.spatial_dimension
+      end
+
       def geometry_type
         Feature::Geometry
       end
@@ -129,6 +137,14 @@ module RGeo
       def is_simple?
         warn "The is_simple? method is deprecated, please use the simple? counterpart, will be removed in v3" unless ENV["RGEO_SILENCE_DEPRECATION"]
         simple?
+      end
+
+      def is_3d?
+        factory.property(:has_z_coordinate)
+      end
+
+      def measured?
+        factory.property(:has_m_coordinate)
       end
 
       def valid?

--- a/lib/rgeo/geos/zm_feature_methods.rb
+++ b/lib/rgeo/geos/zm_feature_methods.rb
@@ -45,6 +45,14 @@ module RGeo
         @zgeometry.dimension
       end
 
+      def coordinate_dimension
+        4
+      end
+
+      def spatial_dimension
+        3
+      end
+
       def geometry_type
         @zgeometry.geometry_type
       end
@@ -81,6 +89,14 @@ module RGeo
       def is_simple?
         warn "The is_simple? method is deprecated, please use the simple? counterpart, will be removed in v3" unless ENV["RGEO_SILENCE_DEPRECATION"]
         simple?
+      end
+
+      def is_3d?
+        true
+      end
+
+      def measured?
+        true
       end
 
       def boundary

--- a/lib/rgeo/impl_helper/validity_check.rb
+++ b/lib/rgeo/impl_helper/validity_check.rb
@@ -22,13 +22,14 @@ module RGeo
       UNCHECKED_METHODS = [
         # Basic methods
         :factory, :geometry_type, :as_text, :as_binary, :srid,
+        :dimension, :coordinate_dimension, :spatial_dimension,
         # Tests
-        :simple?, :closed?, :empty?,
+        :simple?, :closed?, :empty?, :is_3d?, :measured?,
         # Accessors
         :exterior_ring, :interior_rings, :[], :num_geometries, :num_interior_rings,
         :geometry_n, :each, :points, :point_n, :start_point, :end_point, :x, :y, :z, :m,
         # Trivial methods
-        :num_points,
+        :num_points, :locate_along, :locate_between,
         # Comparison
         :equals?, :rep_equals?, :eql?, :==, :'!='
       ].freeze

--- a/test/common/factory_tests.rb
+++ b/test/common/factory_tests.rb
@@ -68,6 +68,33 @@ module RGeo
           assert_equal(@factory, factory2)
           assert_equal(srid, factory2.srid)
         end
+
+        def test_coordinate_dimension
+          dim = 2
+          dim += 1 if @factory.property(:has_z_coordinate)
+          dim += 1 if @factory.property(:has_m_coordinate)
+
+          geom = @factory.point(-10, 20)
+          assert_equal(dim, geom.coordinate_dimension)
+        end
+
+        def test_spatial_dimension
+          dim = 2
+          dim += 1 if @factory.property(:has_z_coordinate)
+
+          geom = @factory.point(-10, 20)
+          assert_equal(dim, geom.spatial_dimension)
+        end
+
+        def test_is_3d
+          geom = @factory.point(-10, 20)
+          assert_equal(geom.is_3d?, @factory.property(:has_z_coordinate))
+        end
+
+        def test_measured
+          geom = @factory.point(-10, 20)
+          assert_equal(geom.measured?, @factory.property(:has_m_coordinate))
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #267 

I've implemented all the methods except for `location_along` and `locate_between`. I'm trying to figure out if there's a fairly simple way to do it. PostGIS just returns a `MultiPoint` object and doesn't worry about preserving the geometries if possible. If there's an easy way to flatten all the points of an arbitrary geometry it would be a simple implementation, but from my POV it seems like each geometry type would need a custom implementation for each factory type.