### PR TITLE
Build polygon centroid with polygon factory

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,7 +7,7 @@
 **Bug Fixes**
 
 * Fix memory leak on failing geometry collection creation #301
-* Use polygon factory on build polygon centroid
+* Use polygon factory on build polygon centroid #306
 
 ### 3.0.0-rc.1 / 2022-03-22
 

--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
 **Bug Fixes**
 
 * Fix memory leak on failing geometry collection creation #301
+* Use polygon factory on build polygon centroid
 
 ### 3.0.0-rc.1 / 2022-03-22
 

--- a/lib/rgeo/geographic/spherical_feature_methods.rb
+++ b/lib/rgeo/geographic/spherical_feature_methods.rb
@@ -232,7 +232,7 @@ module RGeo
         centroid_lat /= (6.0 * signed_area)
         centroid_lng /= (6.0 * signed_area)
 
-        RGeo::Geographic.spherical_factory.point(centroid_lat, centroid_lng)
+        factory.point(centroid_lat, centroid_lng)
       end
     end
   end

--- a/test/spherical_geographic/polygon_test.rb
+++ b/test/spherical_geographic/polygon_test.rb
@@ -28,4 +28,16 @@ class SphericalPolygonTest < Minitest::Test # :nodoc:
     polygon = @factory.polygon(exterior)
     assert_equal @factory.point(1.0/3.0, 1.0/3.0), polygon.centroid
   end
+
+  def test_centroid_srid
+    factory = RGeo::Geographic.spherical_factory(srid: 4326)
+
+    point1 = factory.point(0, 0)
+    point2 = factory.point(0, 1)
+    point3 = factory.point(1, 0)
+    exterior = factory.linear_ring([point1, point2, point3, point1])
+    polygon = factory.polygon(exterior)
+
+    assert_equal 4326, polygon.centroid.srid
+  end
 end


### PR DESCRIPTION
### Summary

Use `RGeo::Geographic::SphericalPolygonImpl#factory` to build centroid point for `RGeo::Geographic::SphericalPolygonImpl`

Closes https://github.com/rgeo/rgeo/issues/305