### PR TITLE
Add Checks for Frozen Geometries

### DIFF
--- a/lib/rgeo.rb
+++ b/lib/rgeo.rb
@@ -76,6 +76,7 @@
 #   activerecord-postgis-adapter gem.
 
 require_relative "rgeo/version"
+require_relative "rgeo/logger"
 require_relative "rgeo/error"
 require_relative "rgeo/feature"
 require_relative "rgeo/coord_sys"

--- a/lib/rgeo/geographic/projected_feature_methods.rb
+++ b/lib/rgeo/geographic/projected_feature_methods.rb
@@ -14,8 +14,13 @@ module RGeo
       end
 
       def projection
-        @projection = factory.project(self) unless defined?(@projection)
-        @projection
+        return @projection if defined?(@projection)
+
+        if frozen?
+          return factory.project(self)
+        end
+
+        @projection = factory.project(self)
       end
 
       def envelope

--- a/lib/rgeo/impl_helper/valid_op.rb
+++ b/lib/rgeo/impl_helper/valid_op.rb
@@ -21,6 +21,11 @@ module RGeo
       # @return String
       def invalid_reason
         return @invalid_reason if defined?(@invalid_reason)
+
+        if frozen?
+          return check_valid
+        end
+
         @invalid_reason = check_valid
       end
 

--- a/lib/rgeo/impl_helper/validity_check.rb
+++ b/lib/rgeo/impl_helper/validity_check.rb
@@ -132,6 +132,11 @@ module RGeo
         # `defined?` is a bit faster than `instance_variable_defined?`.
         return @invalid_reason_memo if defined?(@invalid_reason_memo)
 
+        if frozen?
+          RGeo.logger.info("If freezing a geometry, calling valid?, invalid_reason, or check_validity! beforehand will cache the results of the validity check and can potentially improve performance. Define SUPPRESS_RGEO_PERF_WARNING in your environment to disable this message.") unless ENV.key?("SUPPRESS_RGEO_PERF_WARNING")
+          return invalid_reason
+        end
+
         @invalid_reason_memo = invalid_reason
       end
     end

--- a/lib/rgeo/logger.rb
+++ b/lib/rgeo/logger.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "logger"
+
+module RGeo
+  class << self
+    def logger
+      @logger ||= Logger.new($stdout).tap do |l|
+        l.progname = name
+      end
+    end
+    attr_writer :logger
+  end
+end

--- a/test/common/validity_tests.rb
+++ b/test/common/validity_tests.rb
@@ -142,6 +142,20 @@ module RGeo
           square_polygon_expected_area / 2.0 # Once valid!
         end
 
+        def test_validity_frozen
+          skip "Implementation #{@factory.class} does not implement ValidityCheck" unless implements_validity_check?
+
+          geom1 = @factory.point(1, 1)
+          geom1.freeze
+          geom1.check_validity!
+          refute(geom1.instance_variable_defined?(:@invalid_reason_memo))
+
+          geom2 = @factory.point(1, 1)
+          geom2.check_validity!
+          geom2.freeze
+          assert(geom2.instance_variable_defined?(:@invalid_reason_memo))
+        end
+
         def test_invalid_point_invalid_coordinate
           assert_equal(RGeo::Error::INVALID_COORDINATE, invalid_point.invalid_reason)
           assert_equal(false, invalid_point.valid?)


### PR DESCRIPTION
### Summary

* Add checks for frozen geometries on methods that attempt to memoize.
* Add a logger to the root module.
* Log a perf warning message if a geometry hasn't done a validity check before freeze occurs.

### Other Information

Fixes #308 

Will update History once these changes are approved.

