### PR TITLE
feat: add invalid_reason_location method

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 **Minor Changes**
 
 * Implement `coordinate_dimension`, `spatial_dimension`, `is_3d?` and `measured?` for all factories.
+* Add `invalid_reason_location` method to the CAPI factory #310
 
 **Bug Fixes**
 

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -1058,6 +1058,32 @@ static VALUE method_geometry_invalid_reason(VALUE self)
   return result;
 }
 
+static VALUE method_geometry_invalid_reason_location(VALUE self)
+{
+  VALUE result;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  GEOSGeometry* location = NULL;
+
+  result = Qnil;
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+  if (self_geom) {
+    // We use NULL there to tell GEOS that we don't care about the reason.
+    switch(GEOSisValidDetail_r(self_data->geos_context, self_geom, 0, NULL, &location)) {
+      case 0: // invalid
+        result = rgeo_wrap_geos_geometry(self_data->factory, location, Qnil);
+      case 1: // valid
+        break;
+      case 2: // exception
+        break;
+      default:
+        break;
+    };
+  }
+  return result;
+}
+
 static VALUE method_geometry_make_valid(VALUE self)
 {
   RGeo_GeometryData* self_data;
@@ -1156,6 +1182,7 @@ void rgeo_init_geos_geometry()
   rb_define_method(geos_geometry_methods, "sym_difference", method_geometry_sym_difference, 1);
   rb_define_method(geos_geometry_methods, "valid?", method_geometry_is_valid, 0);
   rb_define_method(geos_geometry_methods, "invalid_reason", method_geometry_invalid_reason, 0);
+  rb_define_method(geos_geometry_methods, "invalid_reason_location", method_geometry_invalid_reason_location, 0);
   rb_define_method(geos_geometry_methods, "point_on_surface", method_geometry_point_on_surface, 0);
   rb_define_method(geos_geometry_methods, "make_valid", method_geometry_make_valid, 0);
 }

--- a/test/geos_capi/validity_test.rb
+++ b/test/geos_capi/validity_test.rb
@@ -14,4 +14,19 @@ class GeosValidityTest < Minitest::Test # :nodoc:
   def setup
     @factory = RGeo::Geos.factory
   end
+
+  def test_valid_linear_ring_invalid_reason_location
+    lr = @factory.linear_ring([point1, point3, point2, point4, point1])
+    assert_nil(lr.invalid_reason_location)
+    assert_nil(lr.invalid_reason)
+    assert(lr.valid?)
+  end
+
+  def test_invalid_polygon_self_intersecting_ring_invalid_reason_location
+    hourglass = @factory.linear_ring([point1, point2, point3, point4, point1])
+    poly = @factory.polygon(hourglass)
+    assert_equal(@factory.point(0.5, 0.5), poly.invalid_reason_location)
+    assert_equal(RGeo::Error::SELF_INTERSECTION, poly.invalid_reason)
+    assert_equal(false, poly.valid?)
+  end
 end if RGeo::Geos.capi_supported?


### PR DESCRIPTION
### Summary

This PR adds `invalid_reason_location` method (for GEOS-backed factories).

Example:
```ruby
# From validity tests:
hourglass = @factory.linear_ring([point1, point2, point3, point4, point1])
poly = @factory.polygon(hourglass)

poly.invalid_reason_location
# => #<RGeo::Geos::CAPIPointImpl:0xXXXXXX "POINT (0.5 0.5)">
```

- It's a nice to have feature.
- Helps migrate from RGeo 2 to RGeo 3 (as `invalid_reason` no longer returns the location of the invalid point).

### Other Information

GEOS has a very nice feature of the `GEOSisValidDetail_r` method to return the exact location that makes geometry invalid.

```C
# https://github.com/libgeos/geos/blob/b8331a9cb25dda85731ba10ae247d25f59723d10/capi/geos_ts_c.cpp#L758
char
    GEOSisValidDetail_r(GEOSContextHandle_t extHandle, const Geometry* g,
                        int flags, char** reason, Geometry** location)
```

Knowing the exact location helps a lot to fix invalid geometry.

For example, when you have 100_000 points GeoJSON polygon (created from some noisy GPS track), and there is `Self-intersection` somewhere, it's tough to find the exact place without `invalid_reason_location`.

In RGeo 2, we have used the `invalid_reason` method, parsing its text output with regexp (it contains point location as plain text).

In RGeo 3, `invalid_reason` became unified between Ruby and GEOS-backed factories (that's great 👍 ). But now, it returns only the name of the reason, without location. So, `invalid_reason_location` will fix this gap and helps RGeo2 to RGeo 3 migration.
