### PR TITLE
fix: dont raise exception when invalid geometry compared with itself using equals?

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@
 
 * Fix memory leak on failing geometry collection creation #301
 * Use polygon factory on build polygon centroid #306
+* Don't raise exception when topology-invalid geometry compared with itself (CAPI factory) #311
 
 ### 3.0.0-rc.1 / 2022-03-22
 

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -386,6 +386,11 @@ static VALUE method_geometry_equals(VALUE self, VALUE rhs)
   GEOSContextHandle_t self_context;
   char val;
 
+  // Shortcut when self and rhs are the same object.
+  if (self == rhs) {
+    return Qtrue;
+  }
+
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;

--- a/test/geos_capi/misc_test.rb
+++ b/test/geos_capi/misc_test.rb
@@ -61,6 +61,12 @@ class GeosMiscTest < Minitest::Test # :nodoc:
     assert(geom1.equals?(geom2))
   end
 
+  def test_invalid_geometry_equal_itself
+    geom = @factory.parse_wkt("MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0)), ((0 0, 2 2, 2 0, 0 0)))")
+    assert(geom.eql?(geom))
+    assert(geom.equals?(geom))
+  end
+
   def test_prepare
     p1 = @factory.point(1, 2)
     p2 = @factory.point(3, 4)


### PR DESCRIPTION
### Summary

1. RGeo raises the exception when `==` (alias to `equals?`) is used for some types of invalid geometries (`RGeo::Geos` CAPI factory, GEOS 3.10.2):
```ruby
RGeo::Geos.version
#> "3.10.2"

factory = RGeo::Geos.factory

invalid_geom = factory.parse_wkt("MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0)), ((0 0, 2 2, 2 0, 0 0)))")
invalid_geom.valid?
#> false

valid_geom = factory.parse_wkt("MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0)), ((1 1, 2 2, 2 1, 1 1)))")
valid_geom.valid?
#> true

invalid_geom == valid_geom

#> RGeo::Error::GeosError: TopologyException: side location conflict at 1 0 0. This can occur if the input geometry is invalid.
#>  from (pry):6:in `=='
```

2. Moreover, it raises an exception when we use `==` on the same RGeo ruby object:
```ruby
factory = RGeo::Geos.factory

invalid_geom = factory.parse_wkt("MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0)), ((0 0, 2 2, 2 0, 0 0)))")
invalid_geom.valid?
#> false

invalid_geom == invalid_geom
#> RGeo::Error::GeosError: TopologyException: side location conflict at 1 0 0. This can occur if the input geometry is invalid.
```

It's a complicated issue how to properly deal with the situation described in point 1 in general.
But, from my point of view, `==` should return `true` for the situation described in point 2.

**This PR** short-circuit `equals?` when you compare RGeo geometry with itself (resolving point 2):
```ruby
factory = RGeo::Geos.factory

invalid_geom = factory.parse_wkt("MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0)), ((0 0, 2 2, 2 0, 0 0)))")
invalid_geom.valid?
#> false

invalid_geom == invalid_geom
# > true
```

### Other Information

As a side effect, this short-circuit 300x speeds up `==` for the same RGeo object (because we skip expensive `GEOSEquals_r` method).
```ruby
factory = RGeo::Geos.factory
valid_geom = factory.parse_wkt("MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0)), ((1 1, 2 2, 2 1, 1 1)))")
valid_geom.valid?
#> true

# Before
Benchmark.measure { 1_000_000.times { valid_geom == valid_geom } }
#> @real=17.75

# After
Benchmark.measure { 1_000_000.times { valid_geom == valid_geom } }
#> @real=0.053
```
