### PR TITLE
require ValidityCheck even if geos is not present

### DIFF
--- a/lib/rgeo/cartesian/feature_classes.rb
+++ b/lib/rgeo/cartesian/feature_classes.rb
@@ -6,6 +6,8 @@
 #
 # -----------------------------------------------------------------------------
 
+require_relative "../impl_helper/validity_check"
+
 module RGeo
   module Cartesian
     class PointImpl # :nodoc:


### PR DESCRIPTION
### Summary

The helper `ValidityCheck` is only required in geos specific files, therefore if geos is not installed rgeo raise the following exception when requiring it:

```
/Users/quentinwentzler/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/bundler/gems/rgeo-dec5b55ddb32/lib/rgeo/cartesian/feature_classes.rb:13:in `<class:PointImpl>': uninitialized constant RGeo::ImplHelper::ValidityCheck (NameError)
        from /Users/quentinwentzler/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/bundler/gems/rgeo-dec5b55ddb32/lib/rgeo/cartesian/feature_classes.rb:11:in `<module:Cartesian>'
        from /Users/quentinwentzler/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/bundler/gems/rgeo-dec5b55ddb32/lib/rgeo/cartesian/feature_classes.rb:10:in `<module:RGeo>'
        from /Users/quentinwentzler/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/bundler/gems/rgeo-dec5b55ddb32/lib/rgeo/cartesian/feature_classes.rb:9:in `<top (required)>'
        from /Users/quentinwentzler/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/bundler/gems/rgeo-dec5b55ddb32/lib/rgeo/cartesian.rb:12:in `require_relative'
        from /Users/quentinwentzler/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/bundler/gems/rgeo-dec5b55ddb32/lib/rgeo/cartesian.rb:12:in `<top (required)>'
        from /Users/quentinwentzler/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/bundler/gems/rgeo-dec5b55ddb32/lib/rgeo.rb:85:in `require_relative'
        from /Users/quentinwentzler/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/bundler/gems/rgeo-dec5b55ddb32/lib/rgeo.rb:85:in `<top (required)>'
[...]
```

This pr adds a require in the corresponding location for cartesian, feel free to move it there is a better place :) 

Thanks!
