### PR TITLE
feature: add polygonize method to CAPI factory

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
 
 * Implement `coordinate_dimension`, `spatial_dimension`, `is_3d?` and `measured?` for all factories.
 * Add `invalid_reason_location` method to the CAPI factory #310
+* Add `polygonize` method to the CAPI factory (@aleksejleonov, @tyfoan) #313
 
 **Bug Fixes**
 

--- a/test/geos_capi/geometry_collection_test.rb
+++ b/test/geos_capi/geometry_collection_test.rb
@@ -34,4 +34,15 @@ class GeosGeometryCollectionTest < Minitest::Test # :nodoc:
     assert_equal(noded.count, 4)
     assert(expected_lines.all? { |line| noded.include? line })
   end
+
+  def test_polygonize_collection
+    input = @factory.parse_wkt(
+      "GEOMETRYCOLLECTION(LINESTRING(0 0, 1 1, 1 0, 0 0), POINT(2 2))"
+    )
+    expected = @factory.parse_wkt(
+      "GEOMETRYCOLLECTION(POLYGON ((0 0, 1 1, 1 0, 0 0)))"
+    )
+
+    assert_equal expected, input.polygonize
+  end
 end if RGeo::Geos.capi_supported?

--- a/test/geos_capi/line_string_test.rb
+++ b/test/geos_capi/line_string_test.rb
@@ -22,4 +22,32 @@ class GeosLineStringTest < Minitest::Test # :nodoc:
     interpolated_point = line_string.interpolate_point location
     assert_equal point, interpolated_point
   end
+
+  def test_polygonize_valid_ring
+    input = @factory.parse_wkt("LINESTRING(0 0, 1 1, 1 0, 0 0)")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION(POLYGON ((0 0, 1 1, 1 0, 0 0)))")
+
+    assert_equal expected, input.polygonize
+  end
+
+  def test_polygonize_not_closed_ring
+    input = @factory.parse_wkt("LINESTRING(0 0, 1 1, 1 0)")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION EMPTY")
+
+    assert_equal expected, input.polygonize
+  end
+
+  def test_polygonize_self_intersection
+    input = @factory.parse_wkt("LINESTRING(0 0, 1 1, 1 0, 0 1, 0 0)")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION EMPTY")
+
+    assert_equal expected, input.polygonize
+  end
+
+  def test_polygonize_dangle
+    input = @factory.parse_wkt("LINESTRING(0 0, 2 2, 1 1, 1 0, 0 0)")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION EMPTY")
+
+    assert_equal expected, input.polygonize
+  end
 end if RGeo::Geos.capi_supported?

--- a/test/geos_capi/multi_line_string_test.rb
+++ b/test/geos_capi/multi_line_string_test.rb
@@ -14,4 +14,72 @@ class GeosMultiLineStringTest < Minitest::Test # :nodoc:
   def create_factory
     RGeo::Geos.factory
   end
+
+  def test_polygonize_lines_forming_valid_ring
+    input = @factory.parse_wkt("MULTILINESTRING((0 0, 1 1), (1 1, 1 0), (1 0, 0 0))")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION(POLYGON ((0 0, 1 1, 1 0, 0 0)))")
+
+    assert_equal expected, input.polygonize
+  end
+
+  def test_polygonize_two_valid_rings
+    input = @factory.parse_wkt("MULTILINESTRING(
+      (0 0, 1 1, 1 0, 0 0),
+      (2 2, 3 3, 3 2, 2 2)
+    )")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION(
+      POLYGON ((0 0, 1 1, 1 0, 0 0)),
+      POLYGON ((2 2, 3 3, 3 2, 2 2))
+    )")
+
+    assert_equal expected, input.polygonize
+  end
+
+  def test_polygonize_one_ring_inside_other
+    input = @factory.parse_wkt("MULTILINESTRING(
+      (0 0, 0 3, 3 3, 3 0, 0 0),
+      (1 1, 1 2, 2 2, 2 1, 1 1)
+    )")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION(
+      POLYGON ((0 0, 0 3, 3 3, 3 0, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1)),
+      POLYGON ((1 1, 1 2, 2 2, 2 1, 1 1))
+    )")
+
+    assert_equal expected, input.polygonize
+  end
+
+  def test_polygonize_valid_ring_and_line_over_it
+    input = @factory.parse_wkt("MULTILINESTRING(
+      (0 0, 0 2, 2 2, 2 0, 0 0),
+      (1 0, 1 2)
+    )")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION(
+      POLYGON ((0 0, 0 2, 2 2, 2 0, 0 0))
+    )")
+
+    assert_equal expected, input.polygonize
+  end
+
+  def test_polygonize_two_unclosed_rings_closed_with_one_common_line
+    input = @factory.parse_wkt("MULTILINESTRING(
+      (1 0, 0 0, 0 1, 1 1),
+      (1 1, 2 1, 2 0, 1 0),
+      (1 0, 1 1)
+    )")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION(
+      POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0)),
+      POLYGON ((1 1, 2 1, 2 0, 1 0, 1 1))
+    )")
+
+    assert_equal expected, input.polygonize
+  end
+
+  def test_polygonize_duplicate_edge
+    input = @factory.parse_wkt("MULTILINESTRING(
+      (0 0, 1 1), (1 1, 0 1), (0 1, 0 1), (0 0, 1 1)
+    )")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION EMPTY")
+
+    assert_equal expected, input.polygonize
+  end
 end if RGeo::Geos.capi_supported?

--- a/test/geos_capi/multi_point_test.rb
+++ b/test/geos_capi/multi_point_test.rb
@@ -14,4 +14,11 @@ class GeosMultiPointTest < Minitest::Test # :nodoc:
   def create_factory(opts = {})
     RGeo::Geos.factory(opts)
   end
+
+  def test_polygonize
+    input = @factory.parse_wkt("MULTIPOINT ((1 1))")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION EMPTY")
+
+    assert_equal expected, input.polygonize
+  end
 end if RGeo::Geos.capi_supported?

--- a/test/geos_capi/multi_polygon_test.rb
+++ b/test/geos_capi/multi_polygon_test.rb
@@ -28,4 +28,11 @@ class GeosMultiPolygonTest < Minitest::Test # :nodoc:
     mp = f.multi_polygon([p2, p1])
     mp.centroid.as_text
   end
+
+  def test_polygonize
+    input = @factory.parse_wkt("MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0)))")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION (MULTIPOLYGON (((0 0, 1 1, 1 0, 0 0))))")
+
+    assert_equal expected, input.polygonize
+  end
 end if RGeo::Geos.capi_supported?

--- a/test/geos_capi/point_test.rb
+++ b/test/geos_capi/point_test.rb
@@ -58,4 +58,11 @@ class GeosPointTest < Minitest::Test # :nodoc:
     point = factory.point(11, 12)
     assert_equal(Encoding::ASCII_8BIT, point.as_binary.encoding)
   end
+
+  def test_polygonize
+    input = @factory.parse_wkt("POINT (1 1)")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION EMPTY")
+
+    assert_equal expected, input.polygonize
+  end
 end if RGeo::Geos.capi_supported?

--- a/test/geos_capi/polygon_test.rb
+++ b/test/geos_capi/polygon_test.rb
@@ -165,4 +165,11 @@ class GeosPolygonTest < Minitest::Test # :nodoc:
 
     refute(polygon.simple?)
   end
+
+  def test_polygonize
+    input = @factory.parse_wkt("POLYGON ((0 0, 1 1, 1 0, 0 0))")
+    expected = @factory.parse_wkt("GEOMETRYCOLLECTION (POLYGON ((0 0, 1 1, 1 0, 0 0)))")
+
+    assert_equal expected, input.polygonize
+  end
 end if RGeo::Geos.capi_supported?


### PR DESCRIPTION
### Summary

Adding GEOS `polygonize` to the CAPI factory.

```ruby
input = RGeo::Geos.factory.parse_wkt("LINESTRING(0 0, 1 1, 1 0, 0 0)")
input.polygonize.as_text

# GEOMETRYCOLLECTION(POLYGON ((0 0, 1 1, 1 0, 0 0)))
```

1. `polygonize` added as a common `geometry` method (not only for `Linestring`, `MultiLinestring`, `GeometryCollection`) to be aligned with GEOS API. It works predictably on `Point` and `Polygon` geometries, and this type of unified API seems logical (covered in tests).
2. This PR focuses only on the old `polygonize` GEOS method. There is a newer `polygonize_full` GEOS API method (starting GEOS 3.3) that returns not only a polygonized result, but also detailed error info about Dangles, Cut Edges, and Invalid Ring Lines.

### Other Information

GEOS `polygonize` description:
> Polygonizes a set of Geometries which contain linework that represents the edges of a planar graph.
> All types of Geometry are accepted as input; the constituent linework is extracted as the edges to be polygonized.
> The edges must be correctly noded; that is, they must only meet at their endpoints and not overlap anywhere. If your edges are not already noded, run them through [GEOSUnaryUnion()](https://libgeos.org/doxygen/geos__c_8h.html#ada5b7b39a81b722b97371736ff0b8d29) first. Polygonization will accept incorrectly noded input but will not form polygons from non-noded edges, and reports them as errors.
>
> https://libgeos.org/doxygen/geos__c_8h.html#a9d98e448d3b846d591c726d1c0000d25

This PR is based on @tyfoan work and all comments in #222.