### PR TITLE
Rename CoordinateTrasnform#transform to transform_coords

### DIFF
--- a/lib/rgeo/coord_sys/cs/entities.rb
+++ b/lib/rgeo/coord_sys/cs/entities.rb
@@ -1464,7 +1464,7 @@ module RGeo
         # @param [Integer] y
         # @param [Integer] z optional
         # @return [Array<Integer>] transformed point coordinates in (x,y,z) order
-        def transform(x, y, z = nil)
+        def transform_coords(x, y, z = nil)
           raise NotImplementedError, "#{__method__} is not implemented in the abstract CoordinateTransform class."
         end
 
@@ -1473,7 +1473,7 @@ module RGeo
         # @param [Array<Array<Integer>>] points in (x,y,z) tuples where z is optional
         # @return [Array<Array<Integer>>] list of transformed point coordinates in (x,y,z) order
         def transform_list(points)
-          points.map { |x, y, z| transform(x, y, z) }
+          points.map { |x, y, z| transform_coords(x, y, z) }
         end
 
         # Creates the inverse transform of this object. This method may fail if the transform is not one to

--- a/test/coord_sys/ogc_cs_test.rb
+++ b/test/coord_sys/ogc_cs_test.rb
@@ -308,7 +308,7 @@ class OgcCsTest < Minitest::Test # :nodoc:
     assert_raises(NotImplementedError) { ct.identity? }
     assert_raises(NotImplementedError) { ct.domain_flags([]) }
     assert_raises(NotImplementedError) { ct.codomain_convex_hull([]) }
-    assert_raises(NotImplementedError) { ct.transform(1, 1) }
+    assert_raises(NotImplementedError) { ct.transform_coords(1, 1) }
     assert_raises(NotImplementedError) { ct.transform_list([[1, 1]]) }
 
     inv_ct = ct.inverse


### PR DESCRIPTION
Since the RGeo proj library already implements `transform` to work on an RGeo feature and `transform_coords` to work on floats, we would need to rename `transform_coords` to `transform` and `transform` to `transform_geometry` to match the spec.

This PR changes the abstract `CoordinateTransform` class to use `transform_coords` as the low level transform method. This deviates from the spec, but the ease of upgrade and limiting breaking changes is probably worth it.