### PR TITLE
Proj Rework: Factory Interface Changes

### DIFF
--- a/ext/geos_c_impl/factory.c
+++ b/ext/geos_c_impl/factory.c
@@ -156,9 +156,6 @@ static void mark_factory_func(void* data)
   if (!NIL_P(factory_data->wkrep_wkb_parser)) {
     mark(factory_data->wkrep_wkb_parser);
   }
-  if (!NIL_P(factory_data->proj4_obj)) {
-    mark(factory_data->proj4_obj);
-  }
   if (!NIL_P(factory_data->coord_sys_obj)) {
     mark(factory_data->coord_sys_obj);
   }
@@ -199,9 +196,6 @@ static void compact_factory_func(void* data)
   }
   if (!NIL_P(factory_data->wkrep_wkb_parser)) {
     factory_data->wkrep_wkb_parser = rb_gc_location(factory_data->wkrep_wkb_parser);
-  }
-  if (!NIL_P(factory_data->proj4_obj)) {
-    factory_data->proj4_obj = rb_gc_location(factory_data->proj4_obj);
   }
   if (!NIL_P(factory_data->coord_sys_obj)) {
     factory_data->coord_sys_obj = rb_gc_location(factory_data->coord_sys_obj);
@@ -509,7 +503,7 @@ static VALUE cmethod_factory_supports_unary_union(VALUE klass)
 }
 
 static VALUE cmethod_factory_create(VALUE klass, VALUE flags, VALUE srid, VALUE buffer_resolution,
-  VALUE wkt_generator, VALUE wkb_generator, VALUE proj4_obj, VALUE coord_sys_obj)
+  VALUE wkt_generator, VALUE wkb_generator, VALUE coord_sys_obj)
 {
   VALUE result;
   RGeo_FactoryData* data;
@@ -541,7 +535,6 @@ static VALUE cmethod_factory_create(VALUE klass, VALUE flags, VALUE srid, VALUE 
       data->wkrep_wkb_generator = wkb_generator;
       data->wkrep_wkt_parser = Qnil;
       data->wkrep_wkb_parser = Qnil;
-      data->proj4_obj = proj4_obj;
       data->coord_sys_obj = coord_sys_obj;
       result = TypedData_Wrap_Struct(klass, &rgeo_factory_type, data);
     }
@@ -555,7 +548,7 @@ static VALUE cmethod_factory_create(VALUE klass, VALUE flags, VALUE srid, VALUE 
 
 static VALUE alloc_factory(VALUE klass)
 {
-  return cmethod_factory_create(klass, INT2NUM(0), INT2NUM(0), INT2NUM(0), Qnil, Qnil, Qnil, Qnil);
+  return cmethod_factory_create(klass, INT2NUM(0), INT2NUM(0), INT2NUM(0), Qnil, Qnil, Qnil);
 }
 
 
@@ -604,7 +597,6 @@ static VALUE method_factory_initialize_copy(VALUE self, VALUE orig)
   self_data->wkrep_wkb_generator = Qnil;
   self_data->wkrep_wkt_parser = Qnil;
   self_data->wkrep_wkb_parser = Qnil;
-  self_data->proj4_obj = Qnil;
   self_data->coord_sys_obj = Qnil;
 
   // Copy new data from original object
@@ -617,7 +609,6 @@ static VALUE method_factory_initialize_copy(VALUE self, VALUE orig)
     self_data->wkrep_wkb_generator = orig_data->wkrep_wkb_generator;
     self_data->wkrep_wkt_parser = orig_data->wkrep_wkt_parser;
     self_data->wkrep_wkb_parser = orig_data->wkrep_wkb_parser;
-    self_data->proj4_obj = orig_data->proj4_obj;
     self_data->coord_sys_obj = orig_data->coord_sys_obj;
   }
   return self;
@@ -633,12 +624,6 @@ static VALUE method_set_wkrep_parsers(VALUE self, VALUE wkt_parser, VALUE wkb_pa
   self_data->wkrep_wkb_parser = wkb_parser;
 
   return self;
-}
-
-
-static VALUE method_get_proj4(VALUE self)
-{
-  return RGEO_FACTORY_DATA_PTR(self)->proj4_obj;
 }
 
 
@@ -712,7 +697,6 @@ void rgeo_init_geos_factory()
   rb_define_method(geos_factory_class, "supports_z_or_m?", method_factory_supports_z_or_m_p, 0);
   rb_define_method(geos_factory_class, "prepare_heuristic?", method_factory_prepare_heuristic_p, 0);
   rb_define_method(geos_factory_class, "_set_wkrep_parsers", method_set_wkrep_parsers, 2);
-  rb_define_method(geos_factory_class, "_proj4", method_get_proj4, 0);
   rb_define_method(geos_factory_class, "_coord_sys", method_get_coord_sys, 0);
   rb_define_method(geos_factory_class, "_wkt_generator", method_get_wkt_generator, 0);
   rb_define_method(geos_factory_class, "_wkb_generator", method_get_wkb_generator, 0);
@@ -722,7 +706,7 @@ void rgeo_init_geos_factory()
   rb_define_method(geos_factory_class, "write_for_marshal", method_factory_write_for_marshal, 1);
   rb_define_method(geos_factory_class, "read_for_psych", method_factory_read_for_psych, 1);
   rb_define_method(geos_factory_class, "write_for_psych", method_factory_write_for_psych, 1);
-  rb_define_module_function(geos_factory_class, "_create", cmethod_factory_create, 7);
+  rb_define_module_function(geos_factory_class, "_create", cmethod_factory_create, 6);
   rb_define_module_function(geos_factory_class, "_geos_version", cmethod_factory_geos_version, 0);
   rb_define_module_function(geos_factory_class, "_supports_unary_union?", cmethod_factory_supports_unary_union, 0);
 

--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -30,7 +30,6 @@ typedef struct {
   GEOSWKBReader* marshal_wkb_reader;
   GEOSWKTWriter* psych_wkt_writer;
   GEOSWKBWriter* marshal_wkb_writer;
-  VALUE proj4_obj;
   VALUE coord_sys_obj;
   int flags;
   int srid;

--- a/lib/rgeo.rb
+++ b/lib/rgeo.rb
@@ -16,9 +16,7 @@
 #   Simple Features Specifiation (SFS). This module forms the core of RGeo.
 #
 # * RGeo::CoordSys contains classes for representing spatial
-#   reference systems and coordinate transformations. For example, it
-#   includes a wrapper for the Proj4 library, supporting many geographic
-#   projections.
+#   reference systems and coordinate transformations.
 #
 # * RGeo::Cartesian is a gateway for geometric data implementations
 #   that operate in Caresian (flat) coordinate systems. It also provides a

--- a/lib/rgeo/cartesian/factory.rb
+++ b/lib/rgeo/cartesian/factory.rb
@@ -27,19 +27,28 @@ module RGeo
         @coordinate_dimension += 1 if @has_m
         @spatial_dimension = @has_z ? 3 : 2
 
-        @proj4 = opts[:proj4]
-        if @proj4 && CoordSys.check!(:proj4)
-          if @proj4.is_a?(String) || @proj4.is_a?(Hash)
-            @proj4 = CoordSys::Proj4.create(@proj4)
-          end
+        @coord_sys = opts[:coord_sys]
+        coord_sys_class = opts[:coord_sys_class]
+        unless coord_sys_class.is_a?(Class)
+          coord_sys_class = CoordSys::CONFIG.default_coord_sys_class
+        end
+
+        if @coord_sys.is_a?(String)
+          @coord_sys = coord_sys_class.create_from_wkt(@coord_sys)
+        end
+
+        unless @coord_sys.is_a?(CoordSys::CS::CoordinateSystem)
+          # TODO: should we raise here?
+          @coord_sys = nil
         end
         srid = opts[:srid]
-        @coord_sys = opts[:coord_sys]
-        if @coord_sys.is_a?(String)
-          @coord_sys = CoordSys::CS.create_from_wkt(@coord_sys)
-        end
         srid ||= @coord_sys.authority_code if @coord_sys
         @srid = srid.to_i
+        # Create a coord sys based on the SRID if one was not given
+        if @coord_sys.nil? && srid != 0
+          @coord_sys = coord_sys_class.create(srid)
+        end
+
         @buffer_resolution = opts[:buffer_resolution].to_i
         @buffer_resolution = 1 if @buffer_resolution < 1
 
@@ -80,14 +89,14 @@ module RGeo
         rhs.is_a?(self.class) && @srid == rhs.srid &&
           @has_z == rhs.property(:has_z_coordinate) &&
           @has_m == rhs.property(:has_m_coordinate) &&
-          @proj4.eql?(rhs.proj4)
+          @coord_sys == rhs.instance_variable_get(:@coord_sys)
       end
       alias == eql?
 
       # Standard hash code
 
       def hash
-        @hash ||= [@srid, @has_z, @has_m, @proj4].hash
+        @hash ||= [@srid, @has_z, @has_m, @coord_sys].hash
       end
 
       # Marshal support
@@ -103,18 +112,11 @@ module RGeo
           "wkbp" => @wkb_parser.properties,
           "bufr" => @buffer_resolution
         }
-        hash_["proj4"] = @proj4.marshal_dump if @proj4
         hash_["cs"] = @coord_sys.to_wkt if @coord_sys
         hash_
       end
 
       def marshal_load(data) # :nodoc:
-        if (proj4_data = data["proj4"]) && CoordSys.check!(:proj4)
-          proj4 = CoordSys::Proj4.allocate
-          proj4.marshal_load(proj4_data)
-        else
-          proj4 = nil
-        end
         if (coord_sys_data = data["cs"])
           coord_sys = CoordSys::CS.create_from_wkt(coord_sys_data)
         else
@@ -129,7 +131,6 @@ module RGeo
           wkt_parser: symbolize_hash(data["wktp"]),
           wkb_parser: symbolize_hash(data["wkbp"]),
           buffer_resolution: data["bufr"],
-          proj4: proj4,
           coord_sys: coord_sys
         )
       end
@@ -145,23 +146,10 @@ module RGeo
         coder["wkb_generator"] = @wkb_generator.properties
         coder["wkt_parser"] = @wkt_parser.properties
         coder["wkb_parser"] = @wkb_parser.properties
-        if @proj4
-          str = @proj4.original_str || @proj4.canonical_str
-          coder["proj4"] = @proj4.radians? ? { "proj4" => str, "radians" => true } : str
-        end
         coder["coord_sys"] = @coord_sys.to_wkt if @coord_sys
       end
 
       def init_with(coder) # :nodoc:
-        if (proj4_data = coder["proj4"]) && CoordSys.check!(:proj4)
-          if proj4_data.is_a?(Hash)
-            proj4 = CoordSys::Proj4.create(proj4_data["proj4"], radians: proj4_data["radians"])
-          else
-            proj4 = CoordSys::Proj4.create(proj4_data.to_s)
-          end
-        else
-          proj4 = nil
-        end
         if (coord_sys_data = coder["cs"])
           coord_sys = CoordSys::CS.create_from_wkt(coord_sys_data.to_s)
         else
@@ -176,7 +164,6 @@ module RGeo
           wkt_parser: symbolize_hash(coder["wkt_parser"]),
           wkb_parser: symbolize_hash(coder["wkb_parser"]),
           buffer_resolution: coder["buffer_resolution"],
-          proj4: proj4,
           coord_sys: coord_sys
         )
       end
@@ -265,10 +252,6 @@ module RGeo
       def multi_polygon(elems)
         MultiPolygonImpl.new(self, elems)
       end
-
-      # See RGeo::Feature::Factory#proj4
-
-      attr_reader :proj4
 
       # See RGeo::Feature::Factory#coord_sys
 

--- a/lib/rgeo/cartesian/interface.rb
+++ b/lib/rgeo/cartesian/interface.rb
@@ -61,14 +61,15 @@ module RGeo
       # [<tt>:srid</tt>]
       #   Set the SRID returned by geometries created by this factory.
       #   Default is 0.
-      # [<tt>:proj4</tt>]
-      #   The coordinate system in Proj4 format, either as a
-      #   CoordSys::Proj4 object or as a string or hash representing the
-      #   proj4 format. Optional.
       # [<tt>:coord_sys</tt>]
       #   The coordinate system in OGC form, either as a subclass of
       #   CoordSys::CS::CoordinateSystem, or as a string in WKT format.
-      #   Optional.
+      #   Optional. If no coord_sys is given, but an SRID is the factory
+      #   will try to create one using the CoordSys::CONFIG.default_coord_sys_class
+      #   or the given :coord_sys_class option.
+      # [<tt>:coord_sys_class</tt>]
+      #   CoordSys::CS::CoordinateSystem implementation used to instansiate
+      #   a coord_sys based on the :srid given.
       # [<tt>:has_z_coordinate</tt>]
       #   Support a Z coordinate. Default is false.
       # [<tt>:has_m_coordinate</tt>]

--- a/lib/rgeo/coord_sys.rb
+++ b/lib/rgeo/coord_sys.rb
@@ -6,6 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
+require 'ostruct'
 require_relative "coord_sys/cs/factories"
 require_relative "coord_sys/cs/entities"
 require_relative "coord_sys/cs/wkt_parser"
@@ -24,6 +25,9 @@ module RGeo
   # systems, and other related concepts, as well as a parser for the WKT
   # format for specifying coordinate systems.
   module CoordSys
+    CONFIG = OpenStruct.new
+    CONFIG.default_coord_sys_class = CS::CoordinateSystem
+
     # The only valid key is :proj4
     def self.supported?(key)
       raise(Error::UnsupportedOperation, "Invalid key. The only valid key is :proj4.") unless key == :proj4

--- a/lib/rgeo/coord_sys/cs/entities.rb
+++ b/lib/rgeo/coord_sys/cs/entities.rb
@@ -939,6 +939,15 @@ module RGeo
         def get_units(dimension)
           nil
         end
+
+        class << self
+          def create(defn, *optional)
+            # TODO: should this raise?
+            # Need this so we can maintain consistency with actual
+            # CoordinateSystem implementations
+            nil
+          end
+        end
       end
 
       # == OGC spec description

--- a/lib/rgeo/feature/factory.rb
+++ b/lib/rgeo/feature/factory.rb
@@ -220,14 +220,6 @@ module RGeo
         nil
       end
 
-      # Returns a RGeo::CoordSys::Proj4 representing the projection for
-      # the coordinate system of features created by this factory, or nil
-      # if there is no such proj4 projection.
-
-      def proj4
-        nil
-      end
-
       # Returns the coordinate system specification for the features
       # created by this factory, or nil if there is no such coordinate
       # system.
@@ -262,7 +254,7 @@ module RGeo
       #   the original is already of the desired factory and type
       # [<tt>:project</tt>]
       #   indicates whether to project the coordinates from the source to
-      #   the destination proj4 coordinate system, if available
+      #   the destination coordinate system, if available
       #
       # It should return either a casted result object, false, or nil.
       # A nil return value indicates that casting should be forced to

--- a/lib/rgeo/feature/factory_generator.rb
+++ b/lib/rgeo/feature/factory_generator.rb
@@ -56,16 +56,12 @@ module RGeo
       # [<tt>:srid</tt>]
       #   The SRID for the factory and objects it creates.
       #   Default is usually 0.
-      # [<tt>:proj4</tt>]
-      #   The coordinate system in Proj4 format, either as a
-      #   CoordSys::Proj4 object or as a string or hash representing the
-      #   proj4 format. This is usually an optional parameter; the default
-      #   is usually nil.
       # [<tt>:coord_sys</tt>]
       #   The coordinate system in OGC form, either as a subclass of
       #   CoordSys::CS::CoordinateSystem, or as a string in WKT format.
-      #   This is usually an optional parameter; the default is usually
-      #   nil.
+      #   Optional. If no coord_sys is given, but an SRID is the factory
+      #   will try to create one using the CoordSys::CONFIG.default_coord_sys_class
+      #   or the given :coord_sys_class option. The option is usually nil.
       # [<tt>:has_z_coordinate</tt>]
       #   Support Z coordinates. Default is usually false.
       # [<tt>:has_m_coordinate</tt>]

--- a/lib/rgeo/geographic/factory.rb
+++ b/lib/rgeo/geographic/factory.rb
@@ -36,17 +36,25 @@ module RGeo
         @coordinate_dimension += 1 if @support_m
         @spatial_dimension = @support_z ? 3 : 2
 
-        @srid = (opts[:srid] || 4326).to_i
-        @proj4 = opts[:proj4]
-        if @proj4 && CoordSys.check!(:proj4)
-          if @proj4.is_a?(String) || @proj4.is_a?(Hash)
-            @proj4 = CoordSys::Proj4.create(@proj4)
-          end
-        end
         @coord_sys = opts[:coord_sys]
-        if @coord_sys.is_a?(String)
-          @coord_sys = CoordSys::CS.create_from_wkt(@coord_sys)
+        coord_sys_class = opts[:coord_sys_class]
+        unless coord_sys_class.is_a?(Class)
+          coord_sys_class = CoordSys::CONFIG.default_coord_sys_class
         end
+
+        if @coord_sys.is_a?(String)
+          @coord_sys = coord_sys_class.create_from_wkt(@coord_sys)
+        end
+
+        unless @coord_sys.is_a?(CoordSys::CS::CoordinateSystem)
+          # TODO: should we raise here?
+          @coord_sys = nil
+        end
+        @srid = (opts[:srid] || 4326).to_i
+        if @coord_sys.nil? && srid != 0
+          @coord_sys = coord_sys_class.create(srid)
+        end
+
         @buffer_resolution = opts[:buffer_resolution].to_i
         @buffer_resolution = 1 if @buffer_resolution < 1
 
@@ -89,14 +97,14 @@ module RGeo
           @impl_prefix == rhs_.instance_variable_get(:@impl_prefix) &&
           @support_z == rhs_.instance_variable_get(:@support_z) &&
           @support_m == rhs_.instance_variable_get(:@support_m) &&
-          @proj4 == rhs_.instance_variable_get(:@proj4)
+          @coord_sys == rhs_.instance_variable_get(:@coord_sys)
       end
       alias == eql?
 
       # Standard hash code
 
       def hash
-        @hash ||= [@impl_prefix, @support_z, @support_m, @proj4].hash
+        @hash ||= [@impl_prefix, @support_z, @support_m, @coord_sys].hash
       end
 
       # Marshal support
@@ -113,7 +121,6 @@ module RGeo
           "wkbp" => @wkb_parser.properties,
           "bufr" => @buffer_resolution
         }
-        hash_["proj4"] = @proj4.marshal_dump if @proj4
         hash_["cs"] = @coord_sys.to_wkt if @coord_sys
         if @projector
           hash_["prjc"] = @projector.class.name.sub(/.*::/, "")
@@ -123,12 +130,6 @@ module RGeo
       end
 
       def marshal_load(data_) # :nodoc:
-        if (proj4_data = data_["proj4"]) && CoordSys.check!(:proj4)
-          proj4 = CoordSys::Proj4.allocate
-          proj4.marshal_load(proj4_data)
-        else
-          proj4 = nil
-        end
         if (coord_sys_data = data_["cs"])
           coord_sys = CoordSys::CS.create_from_wkt(coord_sys_data)
         else
@@ -143,7 +144,6 @@ module RGeo
           wkt_parser: symbolize_hash(data_["wktp"]),
           wkb_parser: symbolize_hash(data_["wkbp"]),
           buffer_resolution: data_["bufr"],
-          proj4: proj4,
           coord_sys: coord_sys
         )
         if (proj_klass = data_["prjc"]) && (proj_factory = data_["prjf"])
@@ -168,10 +168,6 @@ module RGeo
         coder["wkt_parser"] = @wkt_parser.properties
         coder["wkb_parser"] = @wkb_parser.properties
         coder["buffer_resolution"] = @buffer_resolution
-        if @proj4
-          str = @proj4.original_str || @proj4.canonical_str
-          coder["proj4"] = @proj4.radians? ? { "proj4" => str, "radians" => true } : str
-        end
         coder["coord_sys"] = @coord_sys.to_wkt if @coord_sys
         if @projector
           coder["projectorclass"] = @projector.class.name.sub(/.*::/, "")
@@ -180,16 +176,6 @@ module RGeo
       end
 
       def init_with(coder) # :nodoc:
-        if (proj4_data = coder["proj4"])
-          CoordSys.check!(:proj4)
-          if proj4_data.is_a?(Hash)
-            proj4 = CoordSys::Proj4.create(proj4_data["proj4"], radians: proj4_data["radians"])
-          else
-            proj4 = CoordSys::Proj4.create(proj4_data.to_s)
-          end
-        else
-          proj4 = nil
-        end
         if (coord_sys_data = coder["cs"])
           coord_sys = CoordSys::CS.create_from_wkt(coord_sys_data.to_s)
         else
@@ -204,7 +190,6 @@ module RGeo
           wkt_parser: symbolize_hash(coder["wkt_parser"]),
           wkb_parser: symbolize_hash(coder["wkb_parser"]),
           buffer_resolution: coder["buffer_resolution"],
-          proj4: proj4,
           coord_sys: coord_sys
         )
         if (proj_klass = coder["projectorclass"]) && (proj_factory = coder["projection_factory"])
@@ -366,10 +351,6 @@ module RGeo
       def multi_polygon(elems)
         @multi_polygon_class.new(self, elems)
       end
-
-      # See RGeo::Feature::Factory#proj4
-
-      attr_reader :proj4
 
       # See RGeo::Feature::Factory#coord_sys
 

--- a/lib/rgeo/geographic/interface.rb
+++ b/lib/rgeo/geographic/interface.rb
@@ -64,19 +64,14 @@ module RGeo
       #   for different kinds of buffers is not specified precisely,
       #   but in general the value is taken as the number of segments
       #   per 90-degree curve.
-      # [<tt>:proj4</tt>]
-      #   Provide the coordinate system in Proj4 format. You may pass
-      #   either an RGeo::CoordSys::Proj4 object, or a string or hash
-      #   containing the Proj4 parameters. This coordinate system must be
-      #   a geographic (lat/long) coordinate system. The default is the
-      #   "popular visualization CRS" (EPSG 4055), represented by
-      #   "<tt>+proj=longlat +a=6378137 +b=6378137 +towgs84=0,0,0,0,0,0,0 +no_defs</tt>".
-      #   Has no effect if Proj4 is not available.
       # [<tt>:coord_sys</tt>]
       #   Provide a coordinate system in OGC format, either as an object
       #   (one of the CoordSys::CS classes) or as a string in WKT format.
       #   This coordinate system must be a GeographicCoordinateSystem.
       #   The default is the "popular visualization CRS" (EPSG 4055).
+      # [<tt>:coord_sys_class</tt>]
+      #   CoordSys::CS::CoordinateSystem implementation used to instansiate
+      #   a coord_sys based on the :srid given.
       # [<tt>:srid</tt>]
       #   The SRID that should be returned by features from this factory.
       #   Default is 4055, indicating EPSG 4055, the "popular
@@ -104,14 +99,12 @@ module RGeo
       #   for WKRep::WKBGenerator.
 
       def spherical_factory(opts = {})
-        proj4 = opts[:proj4]
         coord_sys = opts[:coord_sys]
         srid = opts[:srid]
         srid ||= coord_sys.authority_code if coord_sys
         Geographic::Factory.new("Spherical",
           has_z_coordinate: opts[:has_z_coordinate],
           has_m_coordinate: opts[:has_m_coordinate],
-          proj4: proj4 || proj_4055,
           coord_sys: coord_sys || coord_sys_4055,
           buffer_resolution: opts[:buffer_resolution],
           wkt_parser: opts[:wkt_parser],
@@ -193,7 +186,6 @@ module RGeo
 
       def simple_mercator_factory(opts = {})
         factory = Geographic::Factory.new("Projected",
-          proj4: proj_4326,
           coord_sys: coord_sys_4326,
           srid: 4326,
           wkt_parser: opts[:wkt_parser],
@@ -211,7 +203,7 @@ module RGeo
       end
 
       # Creates and returns a geographic factory that includes a
-      # projection specified by a Proj4 coordinate system. Like all
+      # projection specified by a coordinate system. Like all
       # geographic factories, this one creates features using latitude-
       # longitude values. However, calculations such as intersections are
       # done in the projected coordinate system, and size and distance
@@ -227,28 +219,24 @@ module RGeo
       # === Options
       #
       # When creating a projected implementation, you must provide enough
-      # information to construct a Proj4 specification for the projection.
+      # information to construct a CoordinateSystem specification for the projection.
       # Generally, this means you will provide either the projection's
       # factory itself (via the <tt>:projection_factory</tt> option), in
-      # which case the factory must include a Proj4 coordinate system;
-      # or, alternatively, you should provide the Proj4 coordinate system
+      # which case the factory must include a coord_sys;
+      # or, alternatively, you should provide the coordinate system
       # and let this method construct a projection factory for you (which
       # it will do using the preferred Cartesian factory generator).
-      # If you choose this second method, you may provide the proj4
-      # via the <tt>:projection_proj4</tt> option.
+      # If you choose this second method, you may provide the coord_sys
+      # via the <tt>:projection_coord_sys</tt> or <option or <tt>:projection_srid</tt>.
       #
       # Following are detailed descriptions of the various options you can
       # pass to this method.
       #
       # [<tt>:projection_factory</tt>]
       #   Specify an existing Cartesian factory to use for the projection.
-      #   This factory must have a non-nil Proj4. If this is provided, any
-      #   <tt>:projection_proj4</tt>, <tt>:projection_coord_sys</tt>, and
+      #   This factory must have a non-nil coord_sys. If this is provided, any
+      #   <tt>:projection_coord_sys</tt> and
       #   <tt>:projection_srid</tt> are ignored.
-      # [<tt>:projection_proj4</tt>]
-      #   Specify a Proj4 projection to use to construct the projection
-      #   factory. This may be specified as a CoordSys::Proj4 object, or
-      #   as a Proj4 string or hash representation.
       # [<tt>:projection_coord_sys</tt>]
       #   Specify a OGC coordinate system for the projection. This may be
       #   specified as an RGeo::CoordSys::CS::GeographicCoordinateSystem
@@ -256,16 +244,12 @@ module RGeo
       # [<tt>:projection_srid</tt>]
       #   The SRID value to use for the projection factory. Defaults to
       #   the given projection coordinate system's authority code, or to
-      #   0 if no projection coordinate system is known.
-      # [<tt>:proj4</tt>]
-      #   A proj4 projection for the geographic (lat-lon) factory. You may
-      #   pass either an RGeo::CoordSys::Proj4 object, or a string or hash
-      #   containing the Proj4 parameters. This coordinate system must be
-      #   a geographic (lat/long) coordinate system. It defaults to the
-      #   geographic part of the projection factory's coordinate system.
-      #   Generally, you should leave it at the default unless you want
-      #   the geographic coordinate system to be based on a different
-      #   horizontal datum than the projection.
+      #   0 if no projection coordinate system is known. If this is provided
+      #   without a projection_coord_sys, one will be instansiated from
+      #   the default_coord_sys_class or projection_coord_sys_class if given.
+      # [<tt>:projection_coord_sys_class</tt>]
+      #   Class to create the projection_coord_sys from if only a projection_srid
+      #   is provided.
       # [<tt>:coord_sys</tt>]
       #   An OGC coordinate system for the geographic (lat-lon) factory,
       #   which may be an RGeo::CoordSys::CS::GeographicCoordinateSystem
@@ -315,29 +299,23 @@ module RGeo
       # for more details.
 
       def projected_factory(opts = {})
-        CoordSys.check!(:proj4)
         if (projection_factory = opts[:projection_factory])
           # Get the projection coordinate systems from the given factory
-          projection_proj4 = projection_factory.proj4
-          unless projection_proj4
-            raise ArgumentError, "The :projection_factory does not have a proj4."
-          end
           projection_coord_sys = projection_factory.coord_sys
+          # TODO: may have to change to just CoordinateSystem because the proj4 implementation doesn't subclass ProjectedCoordinateSystem.
+          # Maybe we can use some other method to check
           if projection_coord_sys && !projection_coord_sys.is_a?(CoordSys::CS::ProjectedCoordinateSystem)
             raise ArgumentError, "The :projection_factory's coord_sys is not a ProjectedCoordinateSystem."
           end
           # Determine geographic coordinate system. First check parameters.
-          proj4 = opts[:proj4]
           coord_sys = opts[:coord_sys]
           srid = opts[:srid]
           # Fall back to getting the values from the projection.
-          proj4 ||= projection_proj4.get_geographic || _proj_4326
           coord_sys ||= projection_coord_sys.geographic_coordinate_system if projection_coord_sys
           srid ||= coord_sys.authority_code if coord_sys
           srid ||= 4326
           # Now we should have all the coordinate system info.
           factory = Geographic::Factory.new("Projected",
-            proj4: proj4,
             coord_sys: coord_sys,
             srid: srid.to_i,
             has_z_coordinate: projection_factory.property(:has_z_coordinate),
@@ -348,39 +326,35 @@ module RGeo
             projection_factory)
         else
           # Determine projection coordinate system. First check the parameters.
-          projection_proj4 = opts[:projection_proj4]
           projection_coord_sys = opts[:projection_coord_sys]
           projection_srid = opts[:projection_srid]
+          coord_sys_class = opts[:projection_coord_sys_class]
+          unless coord_sys_class.is_a?(Class)
+            coord_sys_class = CoordSys::CONFIG.default_coord_sys_class
+          end
 
-          # A projection proj4 is absolutely required.
-          unless projection_proj4
-            raise ArgumentError, "Unable to determine the Proj4 for the projected coordinate system."
+          if projection_coord_sys.is_a?(String)
+            projection_coord_sys = coord_sys_class.create_from_wkt(projection_coord_sys)
           end
-          # Check the projection coordinate systems, and parse if needed.
-          if projection_proj4.is_a?(String) || projection_proj4.is_a?(Hash)
-            actual_projection_proj4 = CoordSys::Proj4.create(projection_proj4)
-            unless actual_projection_proj4
-              raise ArgumentError, "Bad proj4 syntax: #{projection_proj4.inspect}"
-            end
-            projection_proj4 = actual_projection_proj4
+
+          if projection_coord_sys.nil? && projection_srid != 0
+            projection_coord_sys = coord_sys_class.create(projection_srid)
           end
+
           if projection_coord_sys && !projection_coord_sys.is_a?(CoordSys::CS::ProjectedCoordinateSystem)
             raise ArgumentError, "The :projection_coord_sys is not a ProjectedCoordinateSystem."
           end
           projection_srid ||= projection_coord_sys.authority_code if projection_coord_sys
           # Determine geographic coordinate system. First check parameters.
-          proj4 = opts[:proj4]
           coord_sys = opts[:coord_sys]
           srid = opts[:srid]
 
           # Fall back to getting the values from the projection.
-          proj4 ||= projection_proj4.get_geographic || _proj_4326
           coord_sys ||= projection_coord_sys.geographic_coordinate_system if projection_coord_sys
           srid ||= coord_sys.authority_code if coord_sys
           srid ||= 4326
           # Now we should have all the coordinate system info.
           factory = Geographic::Factory.new("Projected",
-            proj4: proj4,
             coord_sys: coord_sys,
             srid: srid.to_i,
             has_z_coordinate: opts[:has_z_coordinate],
@@ -388,7 +362,7 @@ module RGeo
             wkt_parser: opts[:wkt_parser], wkt_generator: opts[:wkt_generator],
             wkb_parser: opts[:wkb_parser], wkb_generator: opts[:wkb_generator])
           projector = Geographic::Proj4Projector.create_from_proj4(factory,
-            projection_proj4,
+            nil,
             srid: projection_srid,
             coord_sys: projection_coord_sys,
             buffer_resolution: opts[:buffer_resolution],
@@ -403,30 +377,16 @@ module RGeo
 
       private
 
-      def proj_4055
-        unless defined?(@proj44055)
-          @proj44055 = CoordSys.supported?(:proj4) && CoordSys::Proj4.create("+proj=longlat +a=6378137 +b=6378137 +towgs84=0,0,0,0,0,0,0 +no_defs")
-        end
-        @proj44055
-      end
-
       def coord_sys_4055
         unless defined?(@coord_sys_4055)
-          @coord_sys_4055 = CoordSys::CS.create_from_wkt('GEOGCS["Popular Visualisation CRS",DATUM["Popular_Visualisation_Datum",SPHEROID["Popular Visualisation Sphere",6378137,0,AUTHORITY["EPSG","7059"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6055"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4055"]]')
+          @coord_sys_4055 = CoordSys::CONFIG.default_coord_sys_class.create(4055)
         end
         @coord_sys_4055
       end
 
-      def proj_4326
-        unless defined?(@proj_4326)
-          @proj_4326 = CoordSys.supported?(:proj4) && CoordSys::Proj4.create("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs")
-        end
-        @proj_4326
-      end
-
       def coord_sys_4326
         unless defined?(@coord_sys_4326)
-          @coord_sys_4326 = CoordSys::CS.create_from_wkt('GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]')
+          @coord_sys_4326 = CoordSys::CONFIG.default_coord_sys_class.create(4326)
         end
         @coord_sys_4326
       end

--- a/lib/rgeo/geos/ffi_factory.rb
+++ b/lib/rgeo/geos/ffi_factory.rb
@@ -61,22 +61,24 @@ module RGeo
           @wkb_writer = nil
         end
 
-        # Coordinate system (srid, proj4, and coord_sys)
+        # Coordinate system (srid and coord_sys)
         @srid = opts[:srid]
-        @proj4 = opts[:proj4]
-        if @proj4 && CoordSys.check!(:proj4)
-          if @proj4.is_a?(String) || @proj4.is_a?(Hash)
-            @proj4 = CoordSys::Proj4.create(@proj4)
-          end
-        else
-          @proj4 = nil
-        end
         @coord_sys = opts[:coord_sys]
+        coord_sys_class = opts[:coord_sys_class]
+        unless coord_sys_class.is_a?(Class)
+          coord_sys_class = CoordSys::CONFIG.default_coord_sys_class
+        end
         if @coord_sys.is_a?(String)
-          @coord_sys = CoordSys::CS.create_from_wkt(@coord_sys)
+          @coord_sys = coord_sys_class.create_from_wkt(@coord_sys)
+        end
+        unless @coord_sys.is_a?(CoordSys::CS::CoordinateSystem)
+          @coord_sys = nil
         end
         @srid ||= @coord_sys.authority_code if @coord_sys
         @srid = @srid.to_i
+        if @coord_sys.nil? && @srid != 0
+          @coord_sys = coord_sys_class.create(@srid)
+        end
 
         # Interpret parser options
         wkt_parser = opts[:wkt_parser]
@@ -119,14 +121,14 @@ module RGeo
           @has_z == rhs.property(:has_z_coordinate) &&
           @has_m == rhs.property(:has_m_coordinate) &&
           @buffer_resolution == rhs.property(:buffer_resolution) &&
-          @proj4.eql?(rhs.proj4)
+          @coord_sys.eql?(rhs.coord_sys)
       end
       alias == eql?
 
       # Standard hash code
 
       def hash
-        @hash ||= [@srid, @has_z, @has_m, @buffer_resolution, @proj4].hash
+        @hash ||= [@srid, @has_z, @has_m, @buffer_resolution, @coord_sys].hash
       end
 
       # Marshal support
@@ -143,18 +145,11 @@ module RGeo
           "wkbp" => @wkb_parser.properties,
           "apre" => @_auto_prepare
         }
-        hash["proj4"] = @proj4.marshal_dump if @proj4
         hash["cs"] = @coord_sys.to_wkt if @coord_sys
         hash
       end
 
       def marshal_load(data) # :nodoc:
-        if (proj4_data = data["proj4"]) && CoordSys.check!(:proj4)
-          proj4 = CoordSys::Proj4.allocate
-          proj4.marshal_load(proj4_data)
-        else
-          proj4 = nil
-        end
         if (coord_sys_data = data["cs"])
           coord_sys = CoordSys::CS.create_from_wkt(coord_sys_data)
         else
@@ -170,7 +165,6 @@ module RGeo
           wkt_parser: symbolize_hash(data["wktp"]),
           wkb_parser: symbolize_hash(data["wkbp"]),
           auto_prepare: (data["apre"] ? :simple : :disabled),
-          proj4: proj4,
           coord_sys: coord_sys
         )
       end
@@ -187,24 +181,10 @@ module RGeo
         coder["wkt_parser"] = @wkt_parser.properties
         coder["wkb_parser"] = @wkb_parser.properties
         coder["auto_prepare"] = @_auto_prepare ? "simple" : "disabled"
-        if @proj4
-          str = @proj4.original_str || @proj4.canonical_str
-          coder["proj4"] = @proj4.radians? ? { "proj4" => str, "radians" => true } : str
-        end
         coder["coord_sys"] = @coord_sys.to_wkt if @coord_sys
       end
 
       def init_with(coder) # :nodoc:
-        if (proj4_data = coder["proj4"])
-          CoordSys.check!(:proj4)
-          if proj4_data.is_a?(Hash)
-            proj4 = CoordSys::Proj4.create(proj4_data["proj4"], radians: proj4_data["radians"])
-          else
-            proj4 = CoordSys::Proj4.create(proj4_data.to_s)
-          end
-        else
-          proj4 = nil
-        end
         if (coord_sys_data = coder["cs"])
           coord_sys = CoordSys::CS.create_from_wkt(coord_sys_data.to_s)
         else
@@ -220,7 +200,6 @@ module RGeo
           wkt_parser: symbolize_hash(coder["wkt_parser"]),
           wkb_parser: symbolize_hash(coder["wkb_parser"]),
           auto_prepare: coder["auto_prepare"] == "disabled" ? :disabled : :simple,
-          proj4: proj4,
           coord_sys: coord_sys
         )
       end
@@ -403,10 +382,6 @@ module RGeo
         fg_geom = ::Geos::Utils.create_collection(::Geos::GeomTypes::GEOS_MULTIPOLYGON, elems)
         FFIMultiPolygonImpl.new(self, fg_geom, klasses)
       end
-
-      # See RGeo::Feature::Factory#proj4
-
-      attr_reader :proj4
 
       # See RGeo::Feature::Factory#coord_sys
 

--- a/lib/rgeo/geos/interface.rb
+++ b/lib/rgeo/geos/interface.rb
@@ -127,14 +127,14 @@ module RGeo
       # [<tt>:srid</tt>]
       #   Set the SRID returned by geometries created by this factory.
       #   Default is 0.
-      # [<tt>:proj4</tt>]
-      #   The coordinate system in Proj4 format, either as a
-      #   CoordSys::Proj4 object or as a string or hash representing the
-      #   proj4 format. Optional.
       # [<tt>:coord_sys</tt>]
       #   The coordinate system in OGC form, either as a subclass of
       #   CoordSys::CS::CoordinateSystem, or as a string in WKT format.
-      #   Optional.
+      #   Optional. If not provided, but <tt>:srid</tt> is, a coord_sys
+      #   will be created using the CS::CONFIG.default_coord_sys_class.
+      #  [<tt>:coord_sys_class</tt>]
+      #    The coordinate system implementation to use if you do not want to
+      #    use the CS::CONFIG.default_coord_sys_class. Optional.
       # [<tt>:has_z_coordinate</tt>]
       #   Support <tt>z_coordinate</tt>. Default is false.
       # [<tt>:has_m_coordinate</tt>]


### PR DESCRIPTION
### Summary

Removes the `proj4` option from all factories and relies on the `coord_sys` option/attribute to act in its place.

The goal is to decouple this gem from the rgeo-proj4 gem. By replacing `proj4` with `coord_sys` all we will need is an implementation of `CoordSys::CS::CoordinateSystem` in each factory as `@coord_sys` and if a `CoordinateTransform` can be created from them, a transform can be done between factories. 

This change allows us to implement any coordinate transform adapter we desire as long as it provides an implementation of `CoordSys::CS::CoordinateSystem` and `CoordSys::CS::CoordinateTransform`. More importantly, it allows us to use the proj4 gem as an adapter that plugs into this system rather than requiring the core gem to check if proj4 is available anytime a transform is to be done.

Changes:

- Remove `proj4` option from all factory creation interfaces
- Remove `proj4` attribute and references in all factory methods.
- Replace `proj4` references with `coord_sys` where appropriate
- Add `CoordSys::CONFIG.default_coord_sys_class` that specifies which `CoordSys::CS::CoordinateSystem` implementation should be the default one when trying to make `coord_sys` objects.
- Automatically try to create `coord_sys` objects from the given `srid` or `coord_sys` string based on the `default_coord_sys_class`.
- Add `coord_sys_class` option to all factories that can be used to override the `default_coord_sys_class` with a specific implementation.

### Other Information

This is not functional currently and more PRs will have to be done to support transforms again, but this is the first step. See: #317 
