### PR TITLE
fix: Remove specific clean task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,16 +22,6 @@ else
   end
 end
 
-task :clean do
-  clean_files = %w[pkg tmp] +
-    Dir.glob("ext/**/Makefile*") +
-    Dir.glob("ext/**/*.{o,class,log,dSYM}") +
-    Dir.glob("**/*.{bundle,so,dll,rbc,jar}") +
-    Dir.glob("**/.rbx")
-
-  clean_files.each { |path| rm_rf path }
-end
-
 test_config = proc do |t|
   t.libs << "test"
   t.libs << "lib"


### PR DESCRIPTION
Since we are using rake-compiler, temporary files already are in the tmp/ folder. Moreover, this would conflict with having bundle installing dependencies in a `vendor/` local folder, which is used in setup-ruby github action for caching

https://rgeo-workspace.slack.com/archives/C01AFKG7BN0/p1663671354739539