### PR TITLE
Pros Rework: `Feature#cast` Refactor

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,15 +3,18 @@
 **Breaking Changes**
 
 * Remove `SRSDatabase` and `factory_generator` related methods #314
-* `proj4` keyword removed from factory creation and responsibilities have been delegated to `coord_sys`. 
+* `proj4` keyword removed from factory creation and responsibilities have been delegated to `coord_sys`. #322
+* Remove `check!` and `supported?` from `CoordSys` module
+* Change `Feature#cast` to rely on `coord_sys`
 
 **Minor Changes**
 
 * Implement `coordinate_dimension`, `spatial_dimension`, `is_3d?` and `measured?` for all factories.
 * Add `invalid_reason_location` method to the CAPI factory #310
 * Add `polygonize` method to the CAPI factory (@aleksejleonov, @tyfoan) #313
-* Add `CS::CoordinateTransform` class
-* Factories will always create a `CoordinateSystem` given a valid SRID.
+* Add `CS::CoordinateTransform` class #318
+* Factories will always create a `CoordinateSystem` given a valid SRID. #322
+* Add `transform_coords` instance method to `CoordinateSystem`
 
 **Bug Fixes**
 

--- a/lib/rgeo/coord_sys.rb
+++ b/lib/rgeo/coord_sys.rb
@@ -25,15 +25,5 @@ module RGeo
   # format for specifying coordinate systems.
   module CoordSys
     CONFIG = Struct.new(:default_coord_sys_class).new(CS::CoordinateSystem)
-
-    # The only valid key is :proj4
-    def self.supported?(key)
-      raise(Error::UnsupportedOperation, "Invalid key. The only valid key is :proj4.") unless key == :proj4
-      defined?(RGeo::CoordSys::Proj4) && RGeo::CoordSys::Proj4.supported?
-    end
-
-    def self.check!(key)
-      supported?(key) || raise(Error::UnsupportedOperation, "Coordinate system '#{key}' is not supported.")
-    end
   end
 end

--- a/lib/rgeo/coord_sys/cs/entities.rb
+++ b/lib/rgeo/coord_sys/cs/entities.rb
@@ -952,6 +952,13 @@ module RGeo
           "CS"
         end
 
+        # Not an OGC method, but useful for being able to
+        # transform directly from a CoordinateSystem object.
+        def transform_coords(target_cs, x, y, z = nil)
+          ct = CoordinateTransform.create(self, target_cs)
+          ct.transform_coords(x, y, z)
+        end
+
         class << self
           def create(defn, dimension = 2, *optional)
             # Need this so we can maintain consistency with actual

--- a/lib/rgeo/feature/types.rb
+++ b/lib/rgeo/feature/types.rb
@@ -194,15 +194,15 @@ module RGeo
             force_new ? obj.dup : obj
           else
             if type == Point
-              proj = nproj = nil
+              cs = ncs = nil
               if project
-                proj = factory.proj4
-                nproj = nfactory.proj4
+                cs = factory.coord_sys
+                ncs = nfactory.coord_sys
               end
               hasz = factory.property(:has_z_coordinate)
               nhasz = nfactory.property(:has_z_coordinate)
-              if proj && nproj && CoordSys.check!(:proj4)
-                coords = CoordSys::Proj4.transform_coords(proj, nproj, obj.x, obj.y, hasz ? obj.z : nil)
+              if cs && ncs
+                coords = cs.transform_coords(ncs, obj.x, obj.y, hasz ? obj.z : nil)
                 coords << (hasz ? obj.z : 0.0) if nhasz && coords.size < 3
               else
                 coords = [obj.x, obj.y]

--- a/lib/rgeo/geographic/simple_mercator_projector.rb
+++ b/lib/rgeo/geographic/simple_mercator_projector.rb
@@ -14,7 +14,6 @@ module RGeo
       def initialize(geography_factory, opts = {})
         @geography_factory = geography_factory
         @projection_factory = Cartesian.preferred_factory(srid: 3857,
-                                                          proj4: SimpleMercatorProjector._proj4_3857,
                                                           coord_sys: SimpleMercatorProjector._coordsys_3857,
                                                           buffer_resolution: opts[:buffer_resolution],
                                                           has_z_coordinate: opts[:has_z_coordinate],
@@ -90,14 +89,6 @@ module RGeo
         @limits_window ||= ProjectedWindow.new(@geography_factory,
           -20_037_508.342789, -20_037_508.342789, 20_037_508.342789, 20_037_508.342789,
           is_limits: true)
-      end
-
-      def self._proj4_3857 # :nodoc:
-        return unless CoordSys.supported?(:proj4)
-        unless defined?(@proj4_3857)
-          @proj4_3857 = CoordSys::Proj4.create("+proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs")
-        end
-        @proj4_3857
       end
 
       def self._coordsys_3857 # :nodoc:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,3 +38,33 @@ end
 if defined?(GC.auto_compact) == "method"
   GC.auto_compact = true
 end
+
+# Basic test class where transformations will translate
+# based on difference between "value" attribute
+class TestAffineCoordinateSystem < RGeo::CoordSys::CS::CoordinateSystem
+  def initialize(value, dimension, *optional)
+    super(value, dimension, *optional)
+    @value = value
+  end
+  attr_accessor :value
+
+  def transform_coords(target_cs, x, y, z = nil)
+    ct = TestAffineCoordinateTransform.create(self, target_cs)
+    ct.transform_coords(x, y, z)
+  end
+
+  class << self
+    def create(value, dimension = 2)
+      new(value, dimension)
+    end
+  end
+end
+
+class TestAffineCoordinateTransform < RGeo::CoordSys::CS::CoordinateTransform
+  def transform_coords(x, y, z = nil)
+    diff = target_cs.value - source_cs.value
+    coords = [x + diff, y + diff]
+    coords << (z + diff) if z
+    coords
+  end
+end

--- a/test/types_test.rb
+++ b/test/types_test.rb
@@ -38,6 +38,30 @@ class TypesTest < Minitest::Test
     assert_nil RGeo::Feature.cast(point, RGeo::Feature::Line)
   end
 
+  def test_cast_with_unimplemented_coordinate_transform
+    fac1 = RGeo::Cartesian.preferred_factory(srid: 4326)
+    fac2 = RGeo::Cartesian.preferred_factory(srid: 4055)
+
+    point = fac1.point(1, 2)
+    assert_raises(NotImplementedError) do
+      RGeo::Feature.cast(point, factory: fac2, project: true)
+    end
+  end
+
+  def test_cast_with_implemented_coordinate_transform
+    cs1 = TestAffineCoordinateSystem.create(0)
+    cs2 = TestAffineCoordinateSystem.create(10)
+
+    fac1 = RGeo::Cartesian.preferred_factory(coord_sys: cs1)
+    fac2 = RGeo::Cartesian.preferred_factory(coord_sys: cs2)
+
+    point1 = fac1.point(1, 2)
+    point2 = RGeo::Feature.cast(point1, factory: fac2, project: true)
+
+    assert_equal(point2.x, 11)
+    assert_equal(point2.y, 12)
+  end
+
   def test_cast_point_to_same_type
     # geom is a RGeo::Geos::CAPIPointImpl
     geom = wkt_parser.parse("POINT(1 2)")


### PR DESCRIPTION
…. Add transform_coords to CoordinateSystem instance.

### Summary

* Use `coord_sys` instead of `proj4` to transform coordinates in the `cast` method.
* Remove `check!` and `supported?` from `CoordSys` module.
* Add `transform_coords` method to `CS::CoordinateSystem` instances.

### Other Information

Part of the larger proj rework. After this we really just have to refactor the mercator implementation and decide what to do with the `Proj4Projector`. We will also have to add a few methods to the `Proj4` coordinate system implementation in the rgeo-proj4 package as well.