### PR TITLE
One factory

### DIFF
--- a/ext/geos_c_impl/analysis.c
+++ b/ext/geos_c_impl/analysis.c
@@ -35,11 +35,11 @@ rgeo_geos_analysis_ccw_p(VALUE self, VALUE ring)
 
   ring_data = RGEO_GEOMETRY_DATA_PTR(ring);
 
-  coord_seq = GEOSGeom_getCoordSeq_r(ring_data->geos_context, ring_data->geom);
+  coord_seq = GEOSGeom_getCoordSeq(ring_data->geom);
   if (!coord_seq) {
     rb_raise(rb_eGeosError, "Could not retrieve CoordSeq from given ring.");
   }
-  if (!GEOSCoordSeq_isCCW_r(ring_data->geos_context, coord_seq, &is_ccw)) {
+  if (!GEOSCoordSeq_isCCW(coord_seq, &is_ccw)) {
     rb_raise(rb_eGeosError, "Could not determine if the CoordSeq is CCW.");
   }
 

--- a/ext/geos_c_impl/coordinates.c
+++ b/ext/geos_c_impl/coordinates.c
@@ -2,8 +2,7 @@
 #include <ruby.h>
 
 VALUE
-extract_points_from_coordinate_sequence(GEOSContextHandle_t context,
-                                        const GEOSCoordSequence* coord_sequence,
+extract_points_from_coordinate_sequence(const GEOSCoordSequence* coord_sequence,
                                         int zCoordinate)
 {
   VALUE result = Qnil;
@@ -12,7 +11,7 @@ extract_points_from_coordinate_sequence(GEOSContextHandle_t context,
   unsigned int i;
   double val;
 
-  if (GEOSCoordSeq_getSize_r(context, coord_sequence, &count)) {
+  if (GEOSCoordSeq_getSize(coord_sequence, &count)) {
     result = rb_ary_new2(count);
     for (i = 0; i < count; ++i) {
       if (zCoordinate) {
@@ -20,12 +19,12 @@ extract_points_from_coordinate_sequence(GEOSContextHandle_t context,
       } else {
         point = rb_ary_new2(2);
       }
-      GEOSCoordSeq_getX_r(context, coord_sequence, i, &val);
+      GEOSCoordSeq_getX(coord_sequence, i, &val);
       rb_ary_push(point, rb_float_new(val));
-      GEOSCoordSeq_getY_r(context, coord_sequence, i, &val);
+      GEOSCoordSeq_getY(coord_sequence, i, &val);
       rb_ary_push(point, rb_float_new(val));
       if (zCoordinate) {
-        GEOSCoordSeq_getZ_r(context, coord_sequence, i, &val);
+        GEOSCoordSeq_getZ(coord_sequence, i, &val);
         rb_ary_push(point, rb_float_new(val));
       }
       rb_ary_push(result, point);
@@ -36,9 +35,7 @@ extract_points_from_coordinate_sequence(GEOSContextHandle_t context,
 }
 
 VALUE
-extract_points_from_polygon(GEOSContextHandle_t context,
-                            const GEOSGeometry* polygon,
-                            int zCoordinate)
+extract_points_from_polygon(const GEOSGeometry* polygon, int zCoordinate)
 {
   VALUE result = Qnil;
 
@@ -48,24 +45,24 @@ extract_points_from_polygon(GEOSContextHandle_t context,
   unsigned int i;
 
   if (polygon) {
-    ring = GEOSGetExteriorRing_r(context, polygon);
-    coord_sequence = GEOSGeom_getCoordSeq_r(context, ring);
+    ring = GEOSGetExteriorRing(polygon);
+    coord_sequence = GEOSGeom_getCoordSeq(ring);
 
     if (coord_sequence) {
-      interior_ring_count = GEOSGetNumInteriorRings_r(context, polygon);
+      interior_ring_count = GEOSGetNumInteriorRings(polygon);
       result = rb_ary_new2(interior_ring_count + 1); // exterior + inner rings
 
-      rb_ary_push(result,
-                  extract_points_from_coordinate_sequence(
-                    context, coord_sequence, zCoordinate));
+      rb_ary_push(
+        result,
+        extract_points_from_coordinate_sequence(coord_sequence, zCoordinate));
 
       for (i = 0; i < interior_ring_count; ++i) {
-        ring = GEOSGetInteriorRingN_r(context, polygon, i);
-        coord_sequence = GEOSGeom_getCoordSeq_r(context, ring);
+        ring = GEOSGetInteriorRingN(polygon, i);
+        coord_sequence = GEOSGeom_getCoordSeq(ring);
         if (coord_sequence) {
           rb_ary_push(result,
-                      extract_points_from_coordinate_sequence(
-                        context, coord_sequence, zCoordinate));
+                      extract_points_from_coordinate_sequence(coord_sequence,
+                                                              zCoordinate));
         }
       }
     }

--- a/ext/geos_c_impl/coordinates.h
+++ b/ext/geos_c_impl/coordinates.h
@@ -1,8 +1,5 @@
 VALUE
-extract_points_from_coordinate_sequence(GEOSContextHandle_t context,
-                                        const GEOSCoordSequence* coord_sequence,
+extract_points_from_coordinate_sequence(const GEOSCoordSequence* coord_sequence,
                                         int zCoordinate);
 VALUE
-extract_points_from_polygon(GEOSContextHandle_t context,
-                            const GEOSGeometry* polygon,
-                            int zCoordinate);
+extract_points_from_polygon(const GEOSGeometry* polygon, int zCoordinate);

--- a/ext/geos_c_impl/factory.c
+++ b/ext/geos_c_impl/factory.c
@@ -24,42 +24,39 @@ RGEO_BEGIN_C
 /**** RUBY AND GEOS CALLBACKS ****/
 
 // Destroy function for factory data. We destroy any serialization
-// objects that have been created for the factory, and then destroy
-// the GEOS context, before freeing the factory data itself.
+// objects that have been created for the factory before freeing
+// the factory data itself.
 
 static void
 destroy_factory_func(void* data)
 {
   RGeo_FactoryData* factory_data;
-  GEOSContextHandle_t context;
 
   factory_data = (RGeo_FactoryData*)data;
-  context = factory_data->geos_context;
   if (factory_data->wkt_reader) {
-    GEOSWKTReader_destroy_r(context, factory_data->wkt_reader);
+    GEOSWKTReader_destroy(factory_data->wkt_reader);
   }
   if (factory_data->wkb_reader) {
-    GEOSWKBReader_destroy_r(context, factory_data->wkb_reader);
+    GEOSWKBReader_destroy(factory_data->wkb_reader);
   }
   if (factory_data->wkt_writer) {
-    GEOSWKTWriter_destroy_r(context, factory_data->wkt_writer);
+    GEOSWKTWriter_destroy(factory_data->wkt_writer);
   }
   if (factory_data->wkb_writer) {
-    GEOSWKBWriter_destroy_r(context, factory_data->wkb_writer);
+    GEOSWKBWriter_destroy(factory_data->wkb_writer);
   }
   if (factory_data->psych_wkt_reader) {
-    GEOSWKTReader_destroy_r(context, factory_data->psych_wkt_reader);
+    GEOSWKTReader_destroy(factory_data->psych_wkt_reader);
   }
   if (factory_data->marshal_wkb_reader) {
-    GEOSWKBReader_destroy_r(context, factory_data->marshal_wkb_reader);
+    GEOSWKBReader_destroy(factory_data->marshal_wkb_reader);
   }
   if (factory_data->psych_wkt_writer) {
-    GEOSWKTWriter_destroy_r(context, factory_data->psych_wkt_writer);
+    GEOSWKTWriter_destroy(factory_data->psych_wkt_writer);
   }
   if (factory_data->marshal_wkb_writer) {
-    GEOSWKBWriter_destroy_r(context, factory_data->marshal_wkb_writer);
+    GEOSWKBWriter_destroy(factory_data->marshal_wkb_writer);
   }
-  // finishGEOS_r(context);
   FREE(factory_data);
 }
 
@@ -74,13 +71,13 @@ destroy_geometry_func(void* data)
 
   geometry_data = (RGeo_GeometryData*)data;
   if (geometry_data->geom) {
-    GEOSGeom_destroy_r(geometry_data->geos_context, geometry_data->geom);
+    GEOSGeom_destroy(geometry_data->geom);
   }
   prep = geometry_data->prep;
   if (prep && prep != (const GEOSPreparedGeometry*)1 &&
       prep != (const GEOSPreparedGeometry*)2 &&
       prep != (const GEOSPreparedGeometry*)3) {
-    GEOSPreparedGeom_destroy_r(geometry_data->geos_context, prep);
+    GEOSPreparedGeom_destroy(prep);
   }
   FREE(geometry_data);
 }
@@ -246,22 +243,20 @@ static VALUE
 method_factory_parse_wkt(VALUE self, VALUE str)
 {
   RGeo_FactoryData* self_data;
-  GEOSContextHandle_t self_context;
   GEOSWKTReader* wkt_reader;
   VALUE result;
   GEOSGeometry* geom;
 
   Check_Type(str, T_STRING);
   self_data = RGEO_FACTORY_DATA_PTR(self);
-  self_context = self_data->geos_context;
   wkt_reader = self_data->wkt_reader;
   if (!wkt_reader) {
-    wkt_reader = GEOSWKTReader_create_r(self_context);
+    wkt_reader = GEOSWKTReader_create();
     self_data->wkt_reader = wkt_reader;
   }
   result = Qnil;
   if (wkt_reader) {
-    geom = GEOSWKTReader_read_r(self_context, wkt_reader, RSTRING_PTR(str));
+    geom = GEOSWKTReader_read(wkt_reader, RSTRING_PTR(str));
     if (geom) {
       result = rgeo_wrap_geos_geometry(self, geom, Qnil);
     }
@@ -273,7 +268,6 @@ static VALUE
 method_factory_parse_wkb(VALUE self, VALUE str)
 {
   RGeo_FactoryData* self_data;
-  GEOSContextHandle_t self_context;
   GEOSWKBReader* wkb_reader;
   VALUE result;
   GEOSGeometry* geom;
@@ -281,25 +275,20 @@ method_factory_parse_wkb(VALUE self, VALUE str)
 
   Check_Type(str, T_STRING);
   self_data = RGEO_FACTORY_DATA_PTR(self);
-  self_context = self_data->geos_context;
   wkb_reader = self_data->wkb_reader;
   if (!wkb_reader) {
-    wkb_reader = GEOSWKBReader_create_r(self_context);
+    wkb_reader = GEOSWKBReader_create();
     self_data->wkb_reader = wkb_reader;
   }
   result = Qnil;
   if (wkb_reader) {
     c_str = RSTRING_PTR(str);
     if (c_str[0] == '\x00' || c_str[0] == '\x01')
-      geom = GEOSWKBReader_read_r(self_context,
-                                  wkb_reader,
-                                  (unsigned char*)c_str,
-                                  (size_t)RSTRING_LEN(str));
+      geom = GEOSWKBReader_read(
+        wkb_reader, (unsigned char*)c_str, (size_t)RSTRING_LEN(str));
     else
-      geom = GEOSWKBReader_readHEX_r(self_context,
-                                     wkb_reader,
-                                     (unsigned char*)c_str,
-                                     (size_t)RSTRING_LEN(str));
+      geom = GEOSWKBReader_readHEX(
+        wkb_reader, (unsigned char*)c_str, (size_t)RSTRING_LEN(str));
     if (geom) {
       result = rgeo_wrap_geos_geometry(self, geom, Qnil);
     }
@@ -311,25 +300,21 @@ static VALUE
 method_factory_read_for_marshal(VALUE self, VALUE str)
 {
   RGeo_FactoryData* self_data;
-  GEOSContextHandle_t self_context;
   GEOSWKBReader* wkb_reader;
   VALUE result;
   GEOSGeometry* geom;
 
   Check_Type(str, T_STRING);
   self_data = RGEO_FACTORY_DATA_PTR(self);
-  self_context = self_data->geos_context;
   wkb_reader = self_data->marshal_wkb_reader;
   if (!wkb_reader) {
-    wkb_reader = GEOSWKBReader_create_r(self_context);
+    wkb_reader = GEOSWKBReader_create();
     self_data->marshal_wkb_reader = wkb_reader;
   }
   result = Qnil;
   if (wkb_reader) {
-    geom = GEOSWKBReader_read_r(self_context,
-                                wkb_reader,
-                                (unsigned char*)RSTRING_PTR(str),
-                                (size_t)RSTRING_LEN(str));
+    geom = GEOSWKBReader_read(
+      wkb_reader, (unsigned char*)RSTRING_PTR(str), (size_t)RSTRING_LEN(str));
     if (geom) {
       result = rgeo_wrap_geos_geometry(self, geom, Qnil);
     }
@@ -341,22 +326,20 @@ static VALUE
 method_factory_read_for_psych(VALUE self, VALUE str)
 {
   RGeo_FactoryData* self_data;
-  GEOSContextHandle_t self_context;
   GEOSWKTReader* wkt_reader;
   VALUE result;
   GEOSGeometry* geom;
 
   Check_Type(str, T_STRING);
   self_data = RGEO_FACTORY_DATA_PTR(self);
-  self_context = self_data->geos_context;
   wkt_reader = self_data->psych_wkt_reader;
   if (!wkt_reader) {
-    wkt_reader = GEOSWKTReader_create_r(self_context);
+    wkt_reader = GEOSWKTReader_create();
     self_data->psych_wkt_reader = wkt_reader;
   }
   result = Qnil;
   if (wkt_reader) {
-    geom = GEOSWKTReader_read_r(self_context, wkt_reader, RSTRING_PTR(str));
+    geom = GEOSWKTReader_read(wkt_reader, RSTRING_PTR(str));
     if (geom) {
       result = rgeo_wrap_geos_geometry(self, geom, Qnil);
     }
@@ -372,7 +355,6 @@ static VALUE
 method_factory_write_for_marshal(VALUE self, VALUE obj)
 {
   RGeo_FactoryData* self_data;
-  GEOSContextHandle_t self_context;
   GEOSWKBWriter* wkb_writer;
   const GEOSGeometry* geom;
   VALUE result;
@@ -381,7 +363,6 @@ method_factory_write_for_marshal(VALUE self, VALUE obj)
   char has_3d;
 
   self_data = RGEO_FACTORY_DATA_PTR(self);
-  self_context = self_data->geos_context;
   has_3d = self_data->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
 #ifndef RGEO_GEOS_SUPPORTS_SETOUTPUTDIMENSION
   if (has_3d) {
@@ -396,9 +377,9 @@ method_factory_write_for_marshal(VALUE self, VALUE obj)
 #endif
   wkb_writer = self_data->marshal_wkb_writer;
   if (!wkb_writer) {
-    wkb_writer = GEOSWKBWriter_create_r(self_context);
+    wkb_writer = GEOSWKBWriter_create();
     if (has_3d) {
-      GEOSWKBWriter_setOutputDimension_r(self_context, wkb_writer, 3);
+      GEOSWKBWriter_setOutputDimension(wkb_writer, 3);
     }
     self_data->marshal_wkb_writer = wkb_writer;
   }
@@ -406,10 +387,10 @@ method_factory_write_for_marshal(VALUE self, VALUE obj)
   if (wkb_writer) {
     geom = rgeo_get_geos_geometry_safe(obj);
     if (geom) {
-      str = (char*)GEOSWKBWriter_write_r(self_context, wkb_writer, geom, &size);
+      str = (char*)GEOSWKBWriter_write(wkb_writer, geom, &size);
       if (str) {
         result = rb_str_new(str, size);
-        GEOSFree_r(self_context, str);
+        GEOSFree(str);
       }
     }
   }
@@ -424,7 +405,6 @@ static VALUE
 method_factory_write_for_psych(VALUE self, VALUE obj)
 {
   RGeo_FactoryData* self_data;
-  GEOSContextHandle_t self_context;
   GEOSWKTWriter* wkt_writer;
   const GEOSGeometry* geom;
   VALUE result;
@@ -432,7 +412,6 @@ method_factory_write_for_psych(VALUE self, VALUE obj)
   char has_3d;
 
   self_data = RGEO_FACTORY_DATA_PTR(self);
-  self_context = self_data->geos_context;
   has_3d = self_data->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
 #ifndef RGEO_GEOS_SUPPORTS_SETOUTPUTDIMENSION
   if (has_3d) {
@@ -447,10 +426,10 @@ method_factory_write_for_psych(VALUE self, VALUE obj)
 #endif
   wkt_writer = self_data->psych_wkt_writer;
   if (!wkt_writer) {
-    wkt_writer = GEOSWKTWriter_create_r(self_context);
-    GEOSWKTWriter_setTrim_r(self_context, wkt_writer, 1);
+    wkt_writer = GEOSWKTWriter_create();
+    GEOSWKTWriter_setTrim(wkt_writer, 1);
     if (has_3d) {
-      GEOSWKTWriter_setOutputDimension_r(self_context, wkt_writer, 3);
+      GEOSWKTWriter_setOutputDimension(wkt_writer, 3);
     }
     self_data->psych_wkt_writer = wkt_writer;
   }
@@ -458,10 +437,10 @@ method_factory_write_for_psych(VALUE self, VALUE obj)
   if (wkt_writer) {
     geom = rgeo_get_geos_geometry_safe(obj);
     if (geom) {
-      str = GEOSWKTWriter_write_r(self_context, wkt_writer, geom);
+      str = GEOSWKTWriter_write(wkt_writer, geom);
       if (str) {
         result = rb_str_new2(str);
-        GEOSFree_r(self_context, str);
+        GEOSFree(str);
       }
     }
   }
@@ -495,35 +474,27 @@ cmethod_factory_create(VALUE klass,
 {
   VALUE result;
   RGeo_FactoryData* data;
-  GEOSContextHandle_t context;
 
   result = Qnil;
   data = ALLOC(RGeo_FactoryData);
   if (data) {
-    context = geos_context;
-
-    if (context) {
-      data->geos_context = context;
-      data->flags = RB_NUM2INT(flags);
-      data->srid = RB_NUM2INT(srid);
-      data->buffer_resolution = RB_NUM2INT(buffer_resolution);
-      data->wkt_reader = NULL;
-      data->wkb_reader = NULL;
-      data->wkt_writer = NULL;
-      data->wkb_writer = NULL;
-      data->psych_wkt_reader = NULL;
-      data->marshal_wkb_reader = NULL;
-      data->psych_wkt_writer = NULL;
-      data->marshal_wkb_writer = NULL;
-      data->wkrep_wkt_generator = wkt_generator;
-      data->wkrep_wkb_generator = wkb_generator;
-      data->wkrep_wkt_parser = Qnil;
-      data->wkrep_wkb_parser = Qnil;
-      data->coord_sys_obj = coord_sys_obj;
-      result = TypedData_Wrap_Struct(klass, &rgeo_factory_type, data);
-    } else {
-      FREE(data);
-    }
+    data->flags = RB_NUM2INT(flags);
+    data->srid = RB_NUM2INT(srid);
+    data->buffer_resolution = RB_NUM2INT(buffer_resolution);
+    data->wkt_reader = NULL;
+    data->wkb_reader = NULL;
+    data->wkt_writer = NULL;
+    data->wkb_writer = NULL;
+    data->psych_wkt_reader = NULL;
+    data->marshal_wkb_reader = NULL;
+    data->psych_wkt_writer = NULL;
+    data->marshal_wkb_writer = NULL;
+    data->wkrep_wkt_generator = wkt_generator;
+    data->wkrep_wkb_generator = wkb_generator;
+    data->wkrep_wkt_parser = Qnil;
+    data->wkrep_wkb_parser = Qnil;
+    data->coord_sys_obj = coord_sys_obj;
+    result = TypedData_Wrap_Struct(klass, &rgeo_factory_type, data);
   }
   return result;
 }
@@ -540,41 +511,39 @@ method_factory_initialize_copy(VALUE self, VALUE orig)
 {
   RGeo_FactoryData* self_data;
   RGeo_FactoryData* orig_data;
-  GEOSContextHandle_t context;
 
   // Clear out existing data
   self_data = RGEO_FACTORY_DATA_PTR(self);
-  context = self_data->geos_context;
   if (self_data->wkt_reader) {
-    GEOSWKTReader_destroy_r(context, self_data->wkt_reader);
+    GEOSWKTReader_destroy(self_data->wkt_reader);
     self_data->wkt_reader = NULL;
   }
   if (self_data->wkb_reader) {
-    GEOSWKBReader_destroy_r(context, self_data->wkb_reader);
+    GEOSWKBReader_destroy(self_data->wkb_reader);
     self_data->wkb_reader = NULL;
   }
   if (self_data->wkt_writer) {
-    GEOSWKTWriter_destroy_r(context, self_data->wkt_writer);
+    GEOSWKTWriter_destroy(self_data->wkt_writer);
     self_data->wkt_writer = NULL;
   }
   if (self_data->wkb_writer) {
-    GEOSWKBWriter_destroy_r(context, self_data->wkb_writer);
+    GEOSWKBWriter_destroy(self_data->wkb_writer);
     self_data->wkb_writer = NULL;
   }
   if (self_data->psych_wkt_reader) {
-    GEOSWKTReader_destroy_r(context, self_data->psych_wkt_reader);
+    GEOSWKTReader_destroy(self_data->psych_wkt_reader);
     self_data->psych_wkt_reader = NULL;
   }
   if (self_data->marshal_wkb_reader) {
-    GEOSWKBReader_destroy_r(context, self_data->marshal_wkb_reader);
+    GEOSWKBReader_destroy(self_data->marshal_wkb_reader);
     self_data->marshal_wkb_reader = NULL;
   }
   if (self_data->psych_wkt_writer) {
-    GEOSWKTWriter_destroy_r(context, self_data->psych_wkt_writer);
+    GEOSWKTWriter_destroy(self_data->psych_wkt_writer);
     self_data->psych_wkt_writer = NULL;
   }
   if (self_data->marshal_wkb_writer) {
-    GEOSWKBWriter_destroy_r(context, self_data->marshal_wkb_writer);
+    GEOSWKBWriter_destroy(self_data->marshal_wkb_writer);
     self_data->marshal_wkb_writer = NULL;
   }
   self_data->wkrep_wkt_generator = Qnil;
@@ -751,7 +720,6 @@ rgeo_wrap_geos_geometry(VALUE factory, GEOSGeometry* geom, VALUE klass)
 {
   VALUE result;
   RGeo_FactoryData* factory_data;
-  GEOSContextHandle_t factory_context;
   VALUE klasses;
   VALUE inferred_klass;
   char is_collection;
@@ -760,16 +728,14 @@ rgeo_wrap_geos_geometry(VALUE factory, GEOSGeometry* geom, VALUE klass)
   result = Qnil;
   if (geom || !NIL_P(klass)) {
     factory_data = NIL_P(factory) ? NULL : RGEO_FACTORY_DATA_PTR(factory);
-    factory_context = factory_data ? factory_data->geos_context : NULL;
 
     // We don't allow "empty" points, so replace such objects with
     // an empty collection.
     if (geom && factory) {
-      if (GEOSGeomTypeId_r(factory_context, geom) == GEOS_POINT &&
-          GEOSGetNumCoordinates_r(factory_context, geom) == 0) {
-        GEOSGeom_destroy_r(factory_context, geom);
-        geom = GEOSGeom_createCollection_r(
-          factory_context, GEOS_GEOMETRYCOLLECTION, NULL, 0);
+      if (GEOSGeomTypeId(geom) == GEOS_POINT &&
+          GEOSGetNumCoordinates(geom) == 0) {
+        GEOSGeom_destroy(geom);
+        geom = GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION, NULL, 0);
         klass = rgeo_geos_geometry_collection_class;
       }
     }
@@ -778,7 +744,7 @@ rgeo_wrap_geos_geometry(VALUE factory, GEOSGeometry* geom, VALUE klass)
     if (TYPE(klass) != T_CLASS) {
       inferred_klass = Qnil;
       is_collection = 0;
-      switch (GEOSGeomTypeId_r(factory_context, geom)) {
+      switch (GEOSGeomTypeId(geom)) {
         case GEOS_POINT:
           inferred_klass = rgeo_geos_point_class;
           break;
@@ -819,9 +785,8 @@ rgeo_wrap_geos_geometry(VALUE factory, GEOSGeometry* geom, VALUE klass)
     data = ALLOC(RGeo_GeometryData);
     if (data) {
       if (geom) {
-        GEOSSetSRID_r(factory_context, geom, factory_data->srid);
+        GEOSSetSRID(geom, factory_data->srid);
       }
-      data->geos_context = factory_context;
       data->geom = geom;
       data->prep =
         factory_data &&
@@ -846,8 +811,7 @@ rgeo_wrap_geos_geometry_clone(VALUE factory,
 
   result = Qnil;
   if (geom) {
-    clone_geom =
-      GEOSGeom_clone_r(RGEO_FACTORY_DATA_PTR(factory)->geos_context, geom);
+    clone_geom = GEOSGeom_clone(geom);
     if (clone_geom) {
       result = rgeo_wrap_geos_geometry(factory, clone_geom, klass);
     }
@@ -913,9 +877,8 @@ rgeo_convert_to_detached_geos_geometry(VALUE obj,
   prep = object_data->prep;
   if (prep && prep != (GEOSPreparedGeometry*)1 &&
       prep != (GEOSPreparedGeometry*)2) {
-    GEOSPreparedGeom_destroy_r(object_data->geos_context, prep);
+    GEOSPreparedGeom_destroy(prep);
   }
-  object_data->geos_context = NULL;
   object_data->geom = NULL;
   object_data->prep = NULL;
   object_data->factory = Qnil;
@@ -947,8 +910,7 @@ rgeo_get_geos_geometry_safe(VALUE obj)
 }
 
 VALUE
-rgeo_geos_coordseqs_eql(GEOSContextHandle_t context,
-                        const GEOSGeometry* geom1,
+rgeo_geos_coordseqs_eql(const GEOSGeometry* geom1,
                         const GEOSGeometry* geom2,
                         char check_z)
 {
@@ -962,30 +924,30 @@ rgeo_geos_coordseqs_eql(GEOSContextHandle_t context,
 
   result = Qnil;
   if (geom1 && geom2) {
-    cs1 = GEOSGeom_getCoordSeq_r(context, geom1);
-    cs2 = GEOSGeom_getCoordSeq_r(context, geom2);
+    cs1 = GEOSGeom_getCoordSeq(geom1);
+    cs2 = GEOSGeom_getCoordSeq(geom2);
     if (cs1 && cs2) {
       len1 = 0;
       len2 = 0;
-      if (GEOSCoordSeq_getSize_r(context, cs1, &len1) &&
-          GEOSCoordSeq_getSize_r(context, cs2, &len2)) {
+      if (GEOSCoordSeq_getSize(cs1, &len1) &&
+          GEOSCoordSeq_getSize(cs2, &len2)) {
         if (len1 == len2) {
           result = Qtrue;
           for (i = 0; i < len1; ++i) {
-            if (GEOSCoordSeq_getX_r(context, cs1, i, &val1) &&
-                GEOSCoordSeq_getX_r(context, cs2, i, &val2)) {
+            if (GEOSCoordSeq_getX(cs1, i, &val1) &&
+                GEOSCoordSeq_getX(cs2, i, &val2)) {
               if (val1 == val2) {
-                if (GEOSCoordSeq_getY_r(context, cs1, i, &val1) &&
-                    GEOSCoordSeq_getY_r(context, cs2, i, &val2)) {
+                if (GEOSCoordSeq_getY(cs1, i, &val1) &&
+                    GEOSCoordSeq_getY(cs2, i, &val2)) {
                   if (val1 == val2) {
                     if (check_z) {
                       val1 = 0;
-                      if (!GEOSCoordSeq_getZ_r(context, cs1, i, &val1)) {
+                      if (!GEOSCoordSeq_getZ(cs1, i, &val1)) {
                         result = Qnil;
                         break;
                       }
                       val2 = 0;
-                      if (!GEOSCoordSeq_getZ_r(context, cs2, i, &val2)) {
+                      if (!GEOSCoordSeq_getZ(cs2, i, &val2)) {
                         result = Qnil;
                         break;
                       }
@@ -1047,9 +1009,7 @@ typedef struct
 } RGeo_Coordseq_Hash_Struct;
 
 st_index_t
-rgeo_geos_coordseq_hash(GEOSContextHandle_t context,
-                        const GEOSGeometry* geom,
-                        st_index_t hash)
+rgeo_geos_coordseq_hash(const GEOSGeometry* geom, st_index_t hash)
 {
   const GEOSCoordSequence* cs;
   unsigned int len;
@@ -1057,13 +1017,13 @@ rgeo_geos_coordseq_hash(GEOSContextHandle_t context,
   RGeo_Coordseq_Hash_Struct hash_struct;
 
   if (geom) {
-    cs = GEOSGeom_getCoordSeq_r(context, geom);
+    cs = GEOSGeom_getCoordSeq(geom);
     if (cs) {
-      if (GEOSCoordSeq_getSize_r(context, cs, &len)) {
+      if (GEOSCoordSeq_getSize(cs, &len)) {
         for (i = 0; i < len; ++i) {
-          if (GEOSCoordSeq_getX_r(context, cs, i, &hash_struct.x)) {
-            if (GEOSCoordSeq_getY_r(context, cs, i, &hash_struct.y)) {
-              if (!GEOSCoordSeq_getY_r(context, cs, i, &hash_struct.z)) {
+          if (GEOSCoordSeq_getX(cs, i, &hash_struct.x)) {
+            if (GEOSCoordSeq_getY(cs, i, &hash_struct.y)) {
+              if (!GEOSCoordSeq_getY(cs, i, &hash_struct.z)) {
                 hash_struct.z = 0;
               }
               hash_struct.seed_hash = hash;

--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -12,13 +12,12 @@ RGEO_BEGIN_C
 
 /*
   Wrapped structure for Factory objects.
-  A factory encapsulates the GEOS context, and GEOS serializer settings.
+  A factory encapsulates GEOS serializer settings.
   It also stores the SRID for all geometries created by this factory,
   and the resolution for buffers created for this factory's geometries.
 */
 typedef struct
 {
-  GEOSContextHandle_t geos_context;
   GEOSWKTReader* wkt_reader;
   GEOSWKBReader* wkb_reader;
   GEOSWKTWriter* wkt_writer;
@@ -85,17 +84,9 @@ method_factory_prepare_heuristic_p(VALUE self);
   in Line objects, which have no GEOS type). Any array element, or the
   array itself, could be Qnil, indicating fall back to the default
   inferred from the GEOS type.
-
-  The GEOS context handle is also included here. Ideally, it would be
-  available by following the factory reference and getting it from the
-  factory data. However, one use case is in the destroy_geometry_func
-  in factory.c, and Rubinius 1.1.1 seems to crash when you try to
-  evaluate a DATA_PTR from that function, so we copy the context handle
-  here so the destroy_geometry_func can get to it.
 */
 typedef struct
 {
-  GEOSContextHandle_t geos_context;
   GEOSGeometry* geom;
   const GEOSPreparedGeometry* prep;
   VALUE factory;
@@ -227,15 +218,13 @@ rgeo_geos_klasses_and_factories_eql(VALUE obj1, VALUE obj2);
 
 /*
   A tool for building up hash values.
-  You must pass in the context, a geos geometry, and a seed hash.
+  You must pass a geos geometry and a seed hash.
   Returns an updated hash.
   This call is useful in sequence, and should be bracketed by calls to
   rb_hash_start and rb_hash_end.
 */
 st_index_t
-rgeo_geos_coordseq_hash(GEOSContextHandle_t context,
-                        const GEOSGeometry* geom,
-                        st_index_t hash);
+rgeo_geos_coordseq_hash(const GEOSGeometry* geom, st_index_t hash);
 
 /*
   A tool for building up hash values.

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -23,7 +23,7 @@ RGEO_BEGIN_C
 // dimension -1. Recursively checks collection elemenets.
 
 static int
-compute_dimension(GEOSContextHandle_t context, const GEOSGeometry* geom)
+compute_dimension(const GEOSGeometry* geom)
 {
   int result;
   int size;
@@ -32,12 +32,12 @@ compute_dimension(GEOSContextHandle_t context, const GEOSGeometry* geom)
 
   result = -1;
   if (geom) {
-    switch (GEOSGeomTypeId_r(context, geom)) {
+    switch (GEOSGeomTypeId(geom)) {
       case GEOS_POINT:
         result = 0;
         break;
       case GEOS_MULTIPOINT:
-        if (!GEOSisEmpty_r(context, geom)) {
+        if (!GEOSisEmpty(geom)) {
           result = 0;
         }
         break;
@@ -46,7 +46,7 @@ compute_dimension(GEOSContextHandle_t context, const GEOSGeometry* geom)
         result = 1;
         break;
       case GEOS_MULTILINESTRING:
-        if (!GEOSisEmpty_r(context, geom)) {
+        if (!GEOSisEmpty(geom)) {
           result = 1;
         }
         break;
@@ -54,15 +54,14 @@ compute_dimension(GEOSContextHandle_t context, const GEOSGeometry* geom)
         result = 2;
         break;
       case GEOS_MULTIPOLYGON:
-        if (!GEOSisEmpty_r(context, geom)) {
+        if (!GEOSisEmpty(geom)) {
           result = 2;
         }
         break;
       case GEOS_GEOMETRYCOLLECTION:
-        size = GEOSGetNumGeometries_r(context, geom);
+        size = GEOSGetNumGeometries(geom);
         for (i = 0; i < size; ++i) {
-          dim =
-            compute_dimension(context, GEOSGetGeometryN_r(context, geom, i));
+          dim = compute_dimension(GEOSGetGeometryN(geom, i));
           if (dim > result) {
             result = dim;
           }
@@ -86,7 +85,7 @@ rgeo_request_prepared_geometry(RGeo_GeometryData* object_data)
     prep = NULL;
   } else if (prep == (const GEOSPreparedGeometry*)2) {
     if (object_data->geom) {
-      prep = GEOSPrepare_r(object_data->geos_context, object_data->geom);
+      prep = GEOSPrepare(object_data->geom);
     } else {
       prep = NULL;
     }
@@ -146,7 +145,7 @@ method_geometry_prepare(VALUE self)
     prep = self_data->prep;
     if (!prep || prep == (const GEOSPreparedGeometry*)1 ||
         prep == (const GEOSPreparedGeometry*)2) {
-      prep = GEOSPrepare_r(self_data->geos_context, self_data->geom);
+      prep = GEOSPrepare(self_data->geom);
       if (prep) {
         self_data->prep = prep;
       } else {
@@ -168,7 +167,7 @@ method_geometry_dimension(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    result = INT2NUM(compute_dimension(self_data->geos_context, self_geom));
+    result = INT2NUM(compute_dimension(self_geom));
   }
   return result;
 }
@@ -198,7 +197,7 @@ method_geometry_srid(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    result = INT2NUM(GEOSGetSRID_r(self_data->geos_context, self_geom));
+    result = INT2NUM(GEOSGetSRID(self_geom));
   }
   return result;
 }
@@ -209,18 +208,15 @@ method_geometry_envelope(VALUE self)
   VALUE result;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t geos_context;
   GEOSGeometry* envelope;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    geos_context = self_data->geos_context;
-    envelope = GEOSEnvelope_r(geos_context, self_geom);
+    envelope = GEOSEnvelope(self_geom);
     if (!envelope) {
-      envelope = GEOSGeom_createCollection_r(
-        geos_context, GEOS_GEOMETRYCOLLECTION, NULL, 0);
+      envelope = GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION, NULL, 0);
     }
     result = rgeo_wrap_geos_geometry(self_data->factory, envelope, Qnil);
   }
@@ -233,15 +229,13 @@ method_geometry_boundary(VALUE self)
   VALUE result;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t geos_context;
   GEOSGeometry* boundary;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    geos_context = self_data->geos_context;
-    boundary = GEOSBoundary_r(geos_context, self_geom);
+    boundary = GEOSBoundary(self_geom);
     if (boundary) {
       result = rgeo_wrap_geos_geometry(self_data->factory, boundary, Qnil);
     }
@@ -258,7 +252,6 @@ method_geometry_as_text(VALUE self)
   RGeo_FactoryData* factory_data;
   VALUE wkt_generator;
   GEOSWKTWriter* wkt_writer;
-  GEOSContextHandle_t geos_context;
   char* str;
 
   result = Qnil;
@@ -271,16 +264,15 @@ method_geometry_as_text(VALUE self)
       result = rb_funcall(wkt_generator, rb_intern("generate"), 1, self);
     } else {
       wkt_writer = factory_data->wkt_writer;
-      geos_context = self_data->geos_context;
       if (!wkt_writer) {
-        wkt_writer = GEOSWKTWriter_create_r(geos_context);
-        GEOSWKTWriter_setTrim_r(geos_context, wkt_writer, 1);
+        wkt_writer = GEOSWKTWriter_create();
+        GEOSWKTWriter_setTrim(wkt_writer, 1);
         factory_data->wkt_writer = wkt_writer;
       }
-      str = GEOSWKTWriter_write_r(geos_context, wkt_writer, self_geom);
+      str = GEOSWKTWriter_write(wkt_writer, self_geom);
       if (str) {
         result = rb_str_new2(str);
-        GEOSFree_r(geos_context, str);
+        GEOSFree(str);
       }
     }
   }
@@ -296,7 +288,6 @@ method_geometry_as_binary(VALUE self)
   RGeo_FactoryData* factory_data;
   VALUE wkb_generator;
   GEOSWKBWriter* wkb_writer;
-  GEOSContextHandle_t geos_context;
   size_t size;
   char* str;
 
@@ -310,16 +301,15 @@ method_geometry_as_binary(VALUE self)
       result = rb_funcall(wkb_generator, rb_intern("generate"), 1, self);
     } else {
       wkb_writer = factory_data->wkb_writer;
-      geos_context = self_data->geos_context;
+
       if (!wkb_writer) {
-        wkb_writer = GEOSWKBWriter_create_r(geos_context);
+        wkb_writer = GEOSWKBWriter_create();
         factory_data->wkb_writer = wkb_writer;
       }
-      str = (char*)GEOSWKBWriter_write_r(
-        geos_context, wkb_writer, self_geom, &size);
+      str = (char*)GEOSWKBWriter_write(wkb_writer, self_geom, &size);
       if (str) {
         result = rb_str_new(str, size);
-        GEOSFree_r(geos_context, str);
+        GEOSFree(str);
       }
     }
   }
@@ -338,7 +328,7 @@ method_geometry_is_empty(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    val = GEOSisEmpty_r(self_data->geos_context, self_geom);
+    val = GEOSisEmpty(self_geom);
     if (val == 0) {
       result = Qfalse;
     } else if (val == 1) {
@@ -360,7 +350,7 @@ method_geometry_is_simple(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    val = GEOSisSimple_r(self_data->geos_context, self_geom);
+    val = GEOSisSimple(self_geom);
     if (val == 0) {
       result = Qfalse;
     } else if (val == 1) {
@@ -377,7 +367,6 @@ method_geometry_equals(VALUE self, VALUE rhs)
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
-  GEOSContextHandle_t self_context;
   char val;
 
   // Shortcut when self and rhs are the same object.
@@ -391,15 +380,12 @@ method_geometry_equals(VALUE self, VALUE rhs)
   if (self_geom) {
     rhs_geom = rgeo_get_geos_geometry_safe(rhs);
     if (rhs_geom) {
-      self_context = self_data->geos_context;
       // GEOS has a bug where empty geometries are not spatially equal
       // to each other. Work around this case first.
-      if (GEOSisEmpty_r(self_context, self_geom) == 1 &&
-          GEOSisEmpty_r(RGEO_GEOMETRY_DATA_PTR(rhs)->geos_context, rhs_geom) ==
-            1) {
+      if (GEOSisEmpty(self_geom) == 1 && GEOSisEmpty(rhs_geom) == 1) {
         result = Qtrue;
       } else {
-        val = GEOSEquals_r(self_context, self_geom, rhs_geom);
+        val = GEOSEquals(self_geom, rhs_geom);
         if (val == 0) {
           result = Qfalse;
         } else if (val == 1) {
@@ -439,10 +425,10 @@ method_geometry_disjoint(VALUE self, VALUE rhs)
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
       prep = rgeo_request_prepared_geometry(self_data);
       if (prep)
-        val = GEOSPreparedDisjoint_r(self_data->geos_context, prep, rhs_geom);
+        val = GEOSPreparedDisjoint(prep, rhs_geom);
       else
 #endif
-        val = GEOSDisjoint_r(self_data->geos_context, self_geom, rhs_geom);
+        val = GEOSDisjoint(self_geom, rhs_geom);
       if (val == 0) {
         result = Qfalse;
       } else if (val == 1) {
@@ -474,10 +460,10 @@ method_geometry_intersects(VALUE self, VALUE rhs)
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED1
       prep = rgeo_request_prepared_geometry(self_data);
       if (prep)
-        val = GEOSPreparedIntersects_r(self_data->geos_context, prep, rhs_geom);
+        val = GEOSPreparedIntersects(prep, rhs_geom);
       else
 #endif
-        val = GEOSIntersects_r(self_data->geos_context, self_geom, rhs_geom);
+        val = GEOSIntersects(self_geom, rhs_geom);
       if (val == 0) {
         result = Qfalse;
       } else if (val == 1) {
@@ -509,10 +495,10 @@ method_geometry_touches(VALUE self, VALUE rhs)
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
       prep = rgeo_request_prepared_geometry(self_data);
       if (prep)
-        val = GEOSPreparedTouches_r(self_data->geos_context, prep, rhs_geom);
+        val = GEOSPreparedTouches(prep, rhs_geom);
       else
 #endif
-        val = GEOSTouches_r(self_data->geos_context, self_geom, rhs_geom);
+        val = GEOSTouches(self_geom, rhs_geom);
       if (val == 0) {
         result = Qfalse;
       } else if (val == 1) {
@@ -544,10 +530,10 @@ method_geometry_crosses(VALUE self, VALUE rhs)
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
       prep = rgeo_request_prepared_geometry(self_data);
       if (prep)
-        val = GEOSPreparedCrosses_r(self_data->geos_context, prep, rhs_geom);
+        val = GEOSPreparedCrosses(prep, rhs_geom);
       else
 #endif
-        val = GEOSCrosses_r(self_data->geos_context, self_geom, rhs_geom);
+        val = GEOSCrosses(self_geom, rhs_geom);
       if (val == 0) {
         result = Qfalse;
       } else if (val == 1) {
@@ -579,10 +565,10 @@ method_geometry_within(VALUE self, VALUE rhs)
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
       prep = rgeo_request_prepared_geometry(self_data);
       if (prep)
-        val = GEOSPreparedWithin_r(self_data->geos_context, prep, rhs_geom);
+        val = GEOSPreparedWithin(prep, rhs_geom);
       else
 #endif
-        val = GEOSWithin_r(self_data->geos_context, self_geom, rhs_geom);
+        val = GEOSWithin(self_geom, rhs_geom);
       if (val == 0) {
         result = Qfalse;
       } else if (val == 1) {
@@ -614,10 +600,10 @@ method_geometry_contains(VALUE self, VALUE rhs)
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED1
       prep = rgeo_request_prepared_geometry(self_data);
       if (prep)
-        val = GEOSPreparedContains_r(self_data->geos_context, prep, rhs_geom);
+        val = GEOSPreparedContains(prep, rhs_geom);
       else
 #endif
-        val = GEOSContains_r(self_data->geos_context, self_geom, rhs_geom);
+        val = GEOSContains(self_geom, rhs_geom);
       if (val == 0) {
         result = Qfalse;
       } else if (val == 1) {
@@ -649,10 +635,10 @@ method_geometry_overlaps(VALUE self, VALUE rhs)
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
       prep = rgeo_request_prepared_geometry(self_data);
       if (prep)
-        val = GEOSPreparedOverlaps_r(self_data->geos_context, prep, rhs_geom);
+        val = GEOSPreparedOverlaps(prep, rhs_geom);
       else
 #endif
-        val = GEOSOverlaps_r(self_data->geos_context, self_geom, rhs_geom);
+        val = GEOSOverlaps(self_geom, rhs_geom);
       if (val == 0) {
         result = Qfalse;
       } else if (val == 1) {
@@ -678,8 +664,7 @@ method_geometry_relate(VALUE self, VALUE rhs, VALUE pattern)
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
     if (rhs_geom) {
-      val = GEOSRelatePattern_r(
-        self_data->geos_context, self_geom, rhs_geom, StringValuePtr(pattern));
+      val = GEOSRelatePattern(self_geom, rhs_geom, StringValuePtr(pattern));
       if (val == 0) {
         result = Qfalse;
       } else if (val == 1) {
@@ -705,7 +690,7 @@ method_geometry_distance(VALUE self, VALUE rhs)
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
     if (rhs_geom) {
-      if (GEOSDistance_r(self_data->geos_context, self_geom, rhs_geom, &dist)) {
+      if (GEOSDistance(self_geom, rhs_geom, &dist)) {
         result = rb_float_new(dist);
       }
     }
@@ -728,10 +713,9 @@ method_geometry_buffer(VALUE self, VALUE distance)
     factory = self_data->factory;
     result = rgeo_wrap_geos_geometry(
       factory,
-      GEOSBuffer_r(self_data->geos_context,
-                   self_geom,
-                   rb_num2dbl(distance),
-                   RGEO_FACTORY_DATA_PTR(factory)->buffer_resolution),
+      GEOSBuffer(self_geom,
+                 rb_num2dbl(distance),
+                 RGEO_FACTORY_DATA_PTR(factory)->buffer_resolution),
       Qnil);
   }
   return result;
@@ -756,13 +740,12 @@ method_geometry_buffer_with_style(VALUE self,
     factory = self_data->factory;
     result = rgeo_wrap_geos_geometry(
       factory,
-      GEOSBufferWithStyle_r(self_data->geos_context,
-                            self_geom,
-                            rb_num2dbl(distance),
-                            RGEO_FACTORY_DATA_PTR(factory)->buffer_resolution,
-                            RB_NUM2INT(endCapStyle),
-                            RB_NUM2INT(joinStyle),
-                            rb_num2dbl(mitreLimit)),
+      GEOSBufferWithStyle(self_geom,
+                          rb_num2dbl(distance),
+                          RGEO_FACTORY_DATA_PTR(factory)->buffer_resolution,
+                          RB_NUM2INT(endCapStyle),
+                          RB_NUM2INT(joinStyle),
+                          rb_num2dbl(mitreLimit)),
       Qnil);
   }
   return result;
@@ -782,9 +765,7 @@ method_geometry_simplify(VALUE self, VALUE tolerance)
   if (self_geom) {
     factory = self_data->factory;
     result = rgeo_wrap_geos_geometry(
-      factory,
-      GEOSSimplify_r(self_data->geos_context, self_geom, rb_num2dbl(tolerance)),
-      Qnil);
+      factory, GEOSSimplify(self_geom, rb_num2dbl(tolerance)), Qnil);
   }
   return result;
 }
@@ -804,8 +785,7 @@ method_geometry_simplify_preserve_topology(VALUE self, VALUE tolerance)
     factory = self_data->factory;
     result = rgeo_wrap_geos_geometry(
       factory,
-      GEOSTopologyPreserveSimplify_r(
-        self_data->geos_context, self_geom, rb_num2dbl(tolerance)),
+      GEOSTopologyPreserveSimplify(self_geom, rb_num2dbl(tolerance)),
       Qnil);
   }
   return result;
@@ -823,9 +803,7 @@ method_geometry_convex_hull(VALUE self)
   self_geom = self_data->geom;
   if (self_geom) {
     result = rgeo_wrap_geos_geometry(
-      self_data->factory,
-      GEOSConvexHull_r(self_data->geos_context, self_geom),
-      Qnil);
+      self_data->factory, GEOSConvexHull(self_geom), Qnil);
   }
   return result;
 }
@@ -847,9 +825,7 @@ method_geometry_intersection(VALUE self, VALUE rhs)
     rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
     if (rhs_geom) {
       result = rgeo_wrap_geos_geometry(
-        factory,
-        GEOSIntersection_r(self_data->geos_context, self_geom, rhs_geom),
-        Qnil);
+        factory, GEOSIntersection(self_geom, rhs_geom), Qnil);
     }
   }
   return result;
@@ -871,10 +847,8 @@ method_geometry_union(VALUE self, VALUE rhs)
     factory = self_data->factory;
     rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
     if (rhs_geom) {
-      result = rgeo_wrap_geos_geometry(
-        factory,
-        GEOSUnion_r(self_data->geos_context, self_geom, rhs_geom),
-        Qnil);
+      result =
+        rgeo_wrap_geos_geometry(factory, GEOSUnion(self_geom, rhs_geom), Qnil);
     }
   }
   return result;
@@ -890,9 +864,8 @@ method_geometry_unary_union(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    GEOSContextHandle_t self_context = self_data->geos_context;
     return rgeo_wrap_geos_geometry(
-      self_data->factory, GEOSUnaryUnion_r(self_context, self_geom), Qnil);
+      self_data->factory, GEOSUnaryUnion(self_geom), Qnil);
   }
 #endif
 
@@ -916,9 +889,7 @@ method_geometry_difference(VALUE self, VALUE rhs)
     rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
     if (rhs_geom) {
       result = rgeo_wrap_geos_geometry(
-        factory,
-        GEOSDifference_r(self_data->geos_context, self_geom, rhs_geom),
-        Qnil);
+        factory, GEOSDifference(self_geom, rhs_geom), Qnil);
     }
   }
   return result;
@@ -941,9 +912,7 @@ method_geometry_sym_difference(VALUE self, VALUE rhs)
     rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
     if (rhs_geom) {
       result = rgeo_wrap_geos_geometry(
-        factory,
-        GEOSSymDifference_r(self_data->geos_context, self_geom, rhs_geom),
-        Qnil);
+        factory, GEOSSymDifference(self_geom, rhs_geom), Qnil);
     }
   }
   return result;
@@ -956,23 +925,21 @@ method_geometry_initialize_copy(VALUE self, VALUE orig)
   const GEOSPreparedGeometry* prep;
   const GEOSGeometry* geom;
   RGeo_GeometryData* orig_data;
-  GEOSContextHandle_t orig_context;
   GEOSGeometry* clone_geom;
   RGeo_FactoryData* factory_data;
 
   // Clear out any existing value
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   if (self_data->geom) {
-    GEOSGeom_destroy_r(self_data->geos_context, self_data->geom);
+    GEOSGeom_destroy(self_data->geom);
     self_data->geom = NULL;
   }
   prep = self_data->prep;
   if (prep && prep != (GEOSPreparedGeometry*)1 &&
       prep != (GEOSPreparedGeometry*)2) {
-    GEOSPreparedGeom_destroy_r(self_data->geos_context, prep);
+    GEOSPreparedGeom_destroy(prep);
   }
   self_data->prep = NULL;
-  self_data->geos_context = NULL;
   self_data->factory = Qnil;
   self_data->klasses = Qnil;
 
@@ -980,14 +947,11 @@ method_geometry_initialize_copy(VALUE self, VALUE orig)
   geom = rgeo_get_geos_geometry_safe(orig);
   if (geom) {
     orig_data = RGEO_GEOMETRY_DATA_PTR(orig);
-    orig_context = orig_data->geos_context;
-    clone_geom = GEOSGeom_clone_r(orig_context, geom);
+    clone_geom = GEOSGeom_clone(geom);
     if (clone_geom) {
       factory_data = RGEO_FACTORY_DATA_PTR(orig_data->factory);
-      GEOSSetSRID_r(
-        orig_context, clone_geom, GEOSGetSRID_r(orig_context, geom));
+      GEOSSetSRID(clone_geom, GEOSGetSRID(geom));
       self_data->geom = clone_geom;
-      self_data->geos_context = orig_context;
       self_data->prep =
         factory_data &&
             ((factory_data->flags & RGEO_FACTORYFLAGS_PREPARE_HEURISTIC) != 0)
@@ -1013,26 +977,24 @@ method_geometry_steal(VALUE self, VALUE orig)
     // Clear out any existing value
     self_data = RGEO_GEOMETRY_DATA_PTR(self);
     if (self_data->geom) {
-      GEOSGeom_destroy_r(self_data->geos_context, self_data->geom);
+      GEOSGeom_destroy(self_data->geom);
     }
     prep = self_data->prep;
     if (prep && prep != (GEOSPreparedGeometry*)1 &&
         prep != (GEOSPreparedGeometry*)2) {
-      GEOSPreparedGeom_destroy_r(self_data->geos_context, prep);
+      GEOSPreparedGeom_destroy(prep);
     }
 
     // Steal value from orig
     orig_data = RGEO_GEOMETRY_DATA_PTR(orig);
     self_data->geom = orig_data->geom;
     self_data->prep = orig_data->prep;
-    self_data->geos_context = orig_data->geos_context;
     self_data->factory = orig_data->factory;
     self_data->klasses = orig_data->klasses;
 
     // Clear out orig
     orig_data->geom = NULL;
     orig_data->prep = NULL;
-    orig_data->geos_context = NULL;
     orig_data->factory = Qnil;
     orig_data->klasses = Qnil;
   }
@@ -1051,7 +1013,7 @@ method_geometry_is_valid(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    val = GEOSisValid_r(self_data->geos_context, self_geom);
+    val = GEOSisValid(self_geom);
     if (val == 0) {
       result = Qfalse;
     } else if (val == 1) {
@@ -1074,8 +1036,7 @@ method_geometry_invalid_reason(VALUE self)
   self_geom = self_data->geom;
   if (self_geom) {
     // We use NULL there to tell GEOS that we don't care about the position.
-    switch (
-      GEOSisValidDetail_r(self_data->geos_context, self_geom, 0, &str, NULL)) {
+    switch (GEOSisValidDetail(self_geom, 0, &str, NULL)) {
       case 0: // invalid
         result = rb_utf8_str_new_cstr(str);
       case 1: // valid
@@ -1086,7 +1047,7 @@ method_geometry_invalid_reason(VALUE self)
         break;
     };
     if (str)
-      GEOSFree_r(self_data->geos_context, str);
+      GEOSFree(str);
   }
   return result;
 }
@@ -1104,8 +1065,7 @@ method_geometry_invalid_reason_location(VALUE self)
   self_geom = self_data->geom;
   if (self_geom) {
     // We use NULL there to tell GEOS that we don't care about the reason.
-    switch (GEOSisValidDetail_r(
-      self_data->geos_context, self_geom, 0, NULL, &location)) {
+    switch (GEOSisValidDetail(self_geom, 0, NULL, &location)) {
       case 0: // invalid
         result = rgeo_wrap_geos_geometry(self_data->factory, location, Qnil);
       case 1: // valid
@@ -1131,7 +1091,7 @@ method_geometry_make_valid(VALUE self)
     return Qnil;
 
   // According to GEOS implementation, MakeValid always returns.
-  valid_geom = GEOSMakeValid_r(self_data->geos_context, self_geom);
+  valid_geom = GEOSMakeValid(self_geom);
   if (!valid_geom) {
     rb_raise(rb_eRGeoInvalidGeometry,
              "%" PRIsVALUE,
@@ -1152,9 +1112,7 @@ method_geometry_point_on_surface(VALUE self)
   self_geom = self_data->geom;
   if (self_geom) {
     result = rgeo_wrap_geos_geometry(
-      self_data->factory,
-      GEOSPointOnSurface_r(self_data->geos_context, self_geom),
-      Qnil);
+      self_data->factory, GEOSPointOnSurface(self_geom), Qnil);
   }
   return result;
 }
@@ -1188,8 +1146,7 @@ method_geometry_polygonize(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    geos_polygon_collection =
-      GEOSPolygonize_r(self_data->geos_context, &self_geom, 1);
+    geos_polygon_collection = GEOSPolygonize(&self_geom, 1);
 
     if (geos_polygon_collection == NULL) {
       rb_raise(rb_eGeosError, "GEOS can't polygonize this geometry.");
@@ -1202,11 +1159,10 @@ method_geometry_polygonize(VALUE self)
 }
 
 VALUE
-rgeo_geos_geometries_strict_eql(GEOSContextHandle_t context,
-                                const GEOSGeometry* geom1,
+rgeo_geos_geometries_strict_eql(const GEOSGeometry* geom1,
                                 const GEOSGeometry* geom2)
 {
-  switch (GEOSEqualsExact_r(context, geom1, geom2, 0.0)) {
+  switch (GEOSEqualsExact(geom1, geom2, 0.0)) {
     case 0:
       return Qfalse;
     case 1:

--- a/ext/geos_c_impl/geometry.h
+++ b/ext/geos_c_impl/geometry.h
@@ -20,8 +20,7 @@ rgeo_init_geos_geometry();
   May raise a `RGeo::Error::GeosError`.
 */
 VALUE
-rgeo_geos_geometries_strict_eql(GEOSContextHandle_t context,
-                                const GEOSGeometry* geom1,
+rgeo_geos_geometries_strict_eql(const GEOSGeometry* geom1,
                                 const GEOSGeometry* geom2);
 
 RGEO_END_C

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -32,7 +32,6 @@ create_geometry_collection(VALUE module, int type, VALUE factory, VALUE array)
   unsigned int len;
   GEOSGeometry** geoms;
   RGeo_FactoryData* factory_data;
-  GEOSContextHandle_t geos_context;
   VALUE klass;
   unsigned int i;
   unsigned int j;
@@ -51,7 +50,6 @@ create_geometry_collection(VALUE module, int type, VALUE factory, VALUE array)
   }
 
   factory_data = RGEO_FACTORY_DATA_PTR(factory);
-  geos_context = factory_data->geos_context;
   klasses = Qnil;
   cast_type = Qnil;
   switch (type) {
@@ -84,10 +82,10 @@ create_geometry_collection(VALUE module, int type, VALUE factory, VALUE array)
   }
   if (i != len) {
     for (j = 0; j < i; ++j) {
-      GEOSGeom_destroy_r(geos_context, geoms[j]);
+      GEOSGeom_destroy(geoms[j]);
     }
   } else {
-    collection = GEOSGeom_createCollection_r(geos_context, type, geoms, len);
+    collection = GEOSGeom_createCollection(type, geoms, len);
     if (collection) {
       result = rgeo_wrap_geos_geometry(factory, collection, module);
       RGEO_GEOMETRY_DATA_PTR(result)->klasses = klasses;
@@ -116,8 +114,7 @@ method_geometry_collection_eql(VALUE self, VALUE rhs)
   result = rgeo_geos_klasses_and_factories_eql(self, rhs);
   if (RTEST(result)) {
     self_data = RGEO_GEOMETRY_DATA_PTR(self);
-    result = rgeo_geos_geometries_strict_eql(self_data->geos_context,
-                                             self_data->geom,
+    result = rgeo_geos_geometries_strict_eql(self_data->geom,
                                              RGEO_GEOMETRY_DATA_PTR(rhs)->geom);
   }
   return result;
@@ -135,8 +132,7 @@ method_geometry_collection_hash(VALUE self)
   hash = rb_hash_start(0);
   hash = rgeo_geos_objbase_hash(
     factory, rgeo_feature_geometry_collection_module, hash);
-  hash = rgeo_geos_geometry_collection_hash(
-    self_data->geos_context, self_data->geom, hash);
+  hash = rgeo_geos_geometry_collection_hash(self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
 
@@ -165,8 +161,7 @@ method_geometry_collection_num_geometries(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    result =
-      INT2NUM(GEOSGetNumGeometries_r(self_data->geos_context, self_geom));
+    result = INT2NUM(GEOSGetNumGeometries(self_geom));
   }
   return result;
 }
@@ -188,15 +183,14 @@ impl_geometry_n(VALUE self, VALUE n, char allow_negatives)
     klasses = self_data->klasses;
     i = RB_NUM2INT(n);
     if (allow_negatives || i >= 0) {
-      GEOSContextHandle_t self_context = self_data->geos_context;
-      len = GEOSGetNumGeometries_r(self_context, self_geom);
+      len = GEOSGetNumGeometries(self_geom);
       if (i < 0) {
         i += len;
       }
       if (i >= 0 && i < len) {
         result = rgeo_wrap_geos_geometry_clone(
           self_data->factory,
-          GEOSGetGeometryN_r(self_context, self_geom, i),
+          GEOSGetGeometryN(self_geom, i),
           NIL_P(klasses) ? Qnil : rb_ary_entry(klasses, i));
       }
     }
@@ -234,12 +228,11 @@ method_geometry_collection_each(VALUE self)
 
   self_geom = self_data->geom;
   if (self_geom) {
-    GEOSContextHandle_t self_context = self_data->geos_context;
-    len = GEOSGetNumGeometries_r(self_context, self_geom);
+    len = GEOSGetNumGeometries(self_geom);
     if (len > 0) {
       klasses = self_data->klasses;
       for (i = 0; i < len; ++i) {
-        elem_geom = GEOSGetGeometryN_r(self_context, self_geom, i);
+        elem_geom = GEOSGetGeometryN(self_geom, i);
         elem = rgeo_wrap_geos_geometry_clone(
           self_data->factory,
           elem_geom,
@@ -278,8 +271,7 @@ method_multi_point_hash(VALUE self)
   factory = self_data->factory;
   hash = rb_hash_start(0);
   hash = rgeo_geos_objbase_hash(factory, rgeo_feature_multi_point_module, hash);
-  hash = rgeo_geos_geometry_collection_hash(
-    self_data->geos_context, self_data->geom, hash);
+  hash = rgeo_geos_geometry_collection_hash(self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
 
@@ -289,7 +281,6 @@ method_multi_point_coordinates(VALUE self)
   VALUE result = Qnil;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t context;
   const GEOSCoordSequence* coord_sequence;
 
   const GEOSGeometry* point;
@@ -303,15 +294,15 @@ method_multi_point_coordinates(VALUE self)
   if (self_geom) {
     zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags &
                   RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
-    context = self_data->geos_context;
-    count = GEOSGetNumGeometries_r(context, self_geom);
+
+    count = GEOSGetNumGeometries(self_geom);
     result = rb_ary_new2(count);
     for (i = 0; i < count; ++i) {
-      point = GEOSGetGeometryN_r(context, self_geom, i);
-      coord_sequence = GEOSGeom_getCoordSeq_r(context, point);
+      point = GEOSGetGeometryN(self_geom, i);
+      coord_sequence = GEOSGeom_getCoordSeq(point);
       rb_ary_push(result,
                   rb_ary_pop(extract_points_from_coordinate_sequence(
-                    context, coord_sequence, zCoordinate)));
+                    coord_sequence, zCoordinate)));
     }
   }
 
@@ -344,8 +335,7 @@ method_multi_line_string_hash(VALUE self)
   hash = rb_hash_start(0);
   hash = rgeo_geos_objbase_hash(
     factory, rgeo_feature_multi_line_string_module, hash);
-  hash = rgeo_geos_geometry_collection_hash(
-    self_data->geos_context, self_data->geom, hash);
+  hash = rgeo_geos_geometry_collection_hash(self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
 
@@ -356,13 +346,11 @@ method_geometry_collection_node(VALUE self)
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
   GEOSGeometry* noded;
-  GEOSContextHandle_t context;
 
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
-  context = self_data->geos_context;
 
-  noded = GEOSNode_r(context, self_geom);
+  noded = GEOSNode(self_geom);
   result = rgeo_wrap_geos_geometry(self_data->factory, noded, Qnil);
 
   return result;
@@ -374,7 +362,6 @@ method_multi_line_string_coordinates(VALUE self)
   VALUE result = Qnil;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t context;
   const GEOSCoordSequence* coord_sequence;
 
   const GEOSGeometry* line_string;
@@ -388,15 +375,14 @@ method_multi_line_string_coordinates(VALUE self)
   if (self_geom) {
     zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags &
                   RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
-    context = self_data->geos_context;
-    count = GEOSGetNumGeometries_r(context, self_geom);
+    count = GEOSGetNumGeometries(self_geom);
     result = rb_ary_new2(count);
     for (i = 0; i < count; ++i) {
-      line_string = GEOSGetGeometryN_r(context, self_geom, i);
-      coord_sequence = GEOSGeom_getCoordSeq_r(context, line_string);
-      rb_ary_push(result,
-                  extract_points_from_coordinate_sequence(
-                    context, coord_sequence, zCoordinate));
+      line_string = GEOSGetGeometryN(self_geom, i);
+      coord_sequence = GEOSGeom_getCoordSeq(line_string);
+      rb_ary_push(
+        result,
+        extract_points_from_coordinate_sequence(coord_sequence, zCoordinate));
     }
   }
 
@@ -415,7 +401,7 @@ method_multi_line_string_length(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    if (GEOSLength_r(self_data->geos_context, self_geom, &len)) {
+    if (GEOSLength(self_geom, &len)) {
       result = rb_float_new(len);
     }
   }
@@ -428,7 +414,6 @@ method_multi_line_string_is_closed(VALUE self)
   VALUE result;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t self_context;
   int len;
   int i;
   const GEOSGeometry* geom;
@@ -437,14 +422,13 @@ method_multi_line_string_is_closed(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    self_context = self_data->geos_context;
     result = Qtrue;
-    len = GEOSGetNumGeometries_r(self_context, self_geom);
+    len = GEOSGetNumGeometries(self_geom);
     if (len > 0) {
       for (i = 0; i < len; ++i) {
-        geom = GEOSGetGeometryN_r(self_context, self_geom, i);
+        geom = GEOSGetGeometryN(self_geom, i);
         if (geom) {
-          result = rgeo_is_geos_line_string_closed(self_context, self_geom);
+          result = rgeo_is_geos_line_string_closed(self_geom);
           if (result != Qtrue) {
             break;
           }
@@ -481,8 +465,7 @@ method_multi_polygon_hash(VALUE self)
   hash = rb_hash_start(0);
   hash =
     rgeo_geos_objbase_hash(factory, rgeo_feature_multi_polygon_module, hash);
-  hash = rgeo_geos_geometry_collection_hash(
-    self_data->geos_context, self_data->geom, hash);
+  hash = rgeo_geos_geometry_collection_hash(self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
 
@@ -492,7 +475,6 @@ method_multi_polygon_coordinates(VALUE self)
   VALUE result = Qnil;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t context;
 
   const GEOSGeometry* poly;
   unsigned int count;
@@ -505,13 +487,11 @@ method_multi_polygon_coordinates(VALUE self)
   if (self_geom) {
     zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags &
                   RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
-    context = self_data->geos_context;
-    count = GEOSGetNumGeometries_r(context, self_geom);
+    count = GEOSGetNumGeometries(self_geom);
     result = rb_ary_new2(count);
     for (i = 0; i < count; ++i) {
-      poly = GEOSGetGeometryN_r(context, self_geom, i);
-      rb_ary_push(result,
-                  extract_points_from_polygon(context, poly, zCoordinate));
+      poly = GEOSGetGeometryN(self_geom, i);
+      rb_ary_push(result, extract_points_from_polygon(poly, zCoordinate));
     }
   }
 
@@ -530,7 +510,7 @@ method_multi_polygon_area(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    if (GEOSArea_r(self_data->geos_context, self_geom, &area)) {
+    if (GEOSArea(self_geom, &area)) {
       result = rb_float_new(area);
     }
   }
@@ -549,9 +529,7 @@ method_multi_polygon_centroid(VALUE self)
   self_geom = self_data->geom;
   if (self_geom) {
     result = rgeo_wrap_geos_geometry(
-      self_data->factory,
-      GEOSGetCentroid_r(self_data->geos_context, self_geom),
-      Qnil);
+      self_data->factory, GEOSGetCentroid(self_geom), Qnil);
   }
   return result;
 }
@@ -706,9 +684,7 @@ rgeo_init_geos_geometry_collection()
 /**** OTHER PUBLIC FUNCTIONS ****/
 
 st_index_t
-rgeo_geos_geometry_collection_hash(GEOSContextHandle_t context,
-                                   const GEOSGeometry* geom,
-                                   st_index_t hash)
+rgeo_geos_geometry_collection_hash(const GEOSGeometry* geom, st_index_t hash)
 {
   const GEOSGeometry* sub_geom;
   int type;
@@ -716,28 +692,27 @@ rgeo_geos_geometry_collection_hash(GEOSContextHandle_t context,
   unsigned int i;
 
   if (geom) {
-    len = GEOSGetNumGeometries_r(context, geom);
+    len = GEOSGetNumGeometries(geom);
     for (i = 0; i < len; ++i) {
-      sub_geom = GEOSGetGeometryN_r(context, geom, i);
+      sub_geom = GEOSGetGeometryN(geom, i);
       if (sub_geom) {
-        type = GEOSGeomTypeId_r(context, sub_geom);
+        type = GEOSGeomTypeId(sub_geom);
         if (type >= 0) {
           hash = hash ^ type;
           switch (type) {
             case GEOS_POINT:
             case GEOS_LINESTRING:
             case GEOS_LINEARRING:
-              hash = rgeo_geos_coordseq_hash(context, sub_geom, hash);
+              hash = rgeo_geos_coordseq_hash(sub_geom, hash);
               break;
             case GEOS_POLYGON:
-              hash = rgeo_geos_polygon_hash(context, sub_geom, hash);
+              hash = rgeo_geos_polygon_hash(sub_geom, hash);
               break;
             case GEOS_GEOMETRYCOLLECTION:
             case GEOS_MULTIPOINT:
             case GEOS_MULTILINESTRING:
             case GEOS_MULTIPOLYGON:
-              hash =
-                rgeo_geos_geometry_collection_hash(context, sub_geom, hash);
+              hash = rgeo_geos_geometry_collection_hash(sub_geom, hash);
               break;
           }
         }

--- a/ext/geos_c_impl/geometry_collection.h
+++ b/ext/geos_c_impl/geometry_collection.h
@@ -19,15 +19,13 @@ rgeo_init_geos_geometry_collection();
 
 /*
   A tool for building up hash values.
-  You must pass in the context, a geos geometry, and a seed hash.
+  You must pass in a geos geometry and a seed hash.
   Returns an updated hash.
   This call is useful in sequence, and should be bracketed by calls to
   rb_hash_start and rb_hash_end.
 */
 st_index_t
-rgeo_geos_geometry_collection_hash(GEOSContextHandle_t context,
-                                   const GEOSGeometry* geom,
-                                   st_index_t hash);
+rgeo_geos_geometry_collection_hash(const GEOSGeometry* geom, st_index_t hash);
 
 RGEO_END_C
 

--- a/ext/geos_c_impl/globals.c
+++ b/ext/geos_c_impl/globals.c
@@ -13,8 +13,6 @@
 
 RGEO_BEGIN_C
 
-GEOSContextHandle_t geos_context;
-
 VALUE rgeo_module;
 
 VALUE rgeo_feature_module;
@@ -45,18 +43,18 @@ VALUE rgeo_geos_multi_polygon_class;
 // GEOSIsValid_r (check for NOTICE_MESSAGE in GEOS codebase).
 // We still set it to make sure we do not miss any implementation
 // change. Use `DEBUG=1 rake` to show notice.
-#ifdef DEBUG
 static void
 notice_handler(const char* fmt, ...)
 {
+#ifdef DEBUG
   va_list args;
   va_start(args, fmt);
   fprintf(stderr, "GEOS Notice -- ");
   vfprintf(stderr, fmt, args);
   fprintf(stderr, "\n");
   va_end(args);
-}
 #endif
+}
 
 static void
 error_handler(const char* fmt, ...)
@@ -94,11 +92,7 @@ error_handler(const char* fmt, ...)
 void
 rgeo_init_geos_globals()
 {
-  geos_context = GEOS_init_r();
-#ifdef DEBUG
-  GEOSContext_setNoticeHandler_r(geos_context, notice_handler);
-#endif
-  GEOSContext_setErrorHandler_r(geos_context, error_handler);
+  initGEOS(notice_handler, error_handler);
 
   rgeo_module = rb_define_module("RGeo");
   rb_gc_register_mark_object(rgeo_module);

--- a/ext/geos_c_impl/globals.h
+++ b/ext/geos_c_impl/globals.h
@@ -8,9 +8,11 @@
 #ifndef RGEO_GEOS_GLOBALS_INCLUDED
 #define RGEO_GEOS_GLOBALS_INCLUDED
 
-#include <ruby.h>
+#include <geos_c.h>
 
 RGEO_BEGIN_C
+
+extern GEOSContextHandle_t geos_context;
 
 extern VALUE rgeo_module;
 

--- a/ext/geos_c_impl/globals.h
+++ b/ext/geos_c_impl/globals.h
@@ -12,8 +12,6 @@
 
 RGEO_BEGIN_C
 
-extern GEOSContextHandle_t geos_context;
-
 extern VALUE rgeo_module;
 
 extern VALUE rgeo_feature_module;

--- a/ext/geos_c_impl/line_string.c
+++ b/ext/geos_c_impl/line_string.c
@@ -73,7 +73,7 @@ method_line_string_length(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    if (GEOSLength_r(self_data->geos_context, self_geom, &len)) {
+    if (GEOSLength(self_geom, &len)) {
       result = rb_float_new(len);
     }
   }
@@ -91,8 +91,7 @@ method_line_string_num_points(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    result =
-      INT2NUM(GEOSGetNumCoordinates_r(self_data->geos_context, self_geom));
+    result = INT2NUM(GEOSGetNumCoordinates(self_geom));
   }
   return result;
 }
@@ -106,8 +105,6 @@ method_line_string_coordinates(VALUE self)
   const GEOSCoordSequence* coord_sequence;
   int zCoordinate;
 
-  GEOSContextHandle_t context;
-
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
@@ -115,11 +112,10 @@ method_line_string_coordinates(VALUE self)
   if (self_geom) {
     zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags &
                   RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
-    context = self_data->geos_context;
-    coord_sequence = GEOSGeom_getCoordSeq_r(context, self_geom);
+    coord_sequence = GEOSGeom_getCoordSeq(self_geom);
     if (coord_sequence) {
-      result = extract_points_from_coordinate_sequence(
-        context, coord_sequence, zCoordinate);
+      result =
+        extract_points_from_coordinate_sequence(coord_sequence, zCoordinate);
     }
   }
   return result;
@@ -133,16 +129,14 @@ get_point_from_coordseq(VALUE self,
 {
   VALUE result;
   RGeo_GeometryData* self_data;
-  GEOSContextHandle_t self_context;
   double x, y, z;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
-  self_context = self_data->geos_context;
-  if (GEOSCoordSeq_getX_r(self_context, coord_seq, i, &x)) {
-    if (GEOSCoordSeq_getY_r(self_context, coord_seq, i, &y)) {
+  if (GEOSCoordSeq_getX(coord_seq, i, &x)) {
+    if (GEOSCoordSeq_getY(coord_seq, i, &y)) {
       if (has_z) {
-        if (!GEOSCoordSeq_getZ_r(self_context, coord_seq, i, &z)) {
+        if (!GEOSCoordSeq_getZ(coord_seq, i, &z)) {
           z = 0.0;
         }
       } else {
@@ -160,7 +154,6 @@ method_line_string_point_n(VALUE self, VALUE n)
   VALUE result;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t self_context;
   const GEOSCoordSequence* coord_seq;
   char has_z;
   int si;
@@ -171,15 +164,14 @@ method_line_string_point_n(VALUE self, VALUE n)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    self_context = self_data->geos_context;
-    coord_seq = GEOSGeom_getCoordSeq_r(self_context, self_geom);
+    coord_seq = GEOSGeom_getCoordSeq(self_geom);
     if (coord_seq) {
       has_z = (char)(RGEO_FACTORY_DATA_PTR(self_data->factory)->flags &
                      RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M);
       si = RB_NUM2INT(n);
       if (si >= 0) {
         i = si;
-        if (GEOSCoordSeq_getSize_r(self_context, coord_seq, &size)) {
+        if (GEOSCoordSeq_getSize(coord_seq, &size)) {
           if (i < size) {
             result = get_point_from_coordseq(self, coord_seq, i, has_z);
           }
@@ -196,7 +188,6 @@ method_line_string_points(VALUE self)
   VALUE result;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t self_context;
   const GEOSCoordSequence* coord_seq;
   char has_z;
   unsigned int size;
@@ -207,12 +198,11 @@ method_line_string_points(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    self_context = self_data->geos_context;
-    coord_seq = GEOSGeom_getCoordSeq_r(self_context, self_geom);
+    coord_seq = GEOSGeom_getCoordSeq(self_geom);
     if (coord_seq) {
       has_z = (char)(RGEO_FACTORY_DATA_PTR(self_data->factory)->flags &
                      RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M);
-      if (GEOSCoordSeq_getSize_r(self_context, coord_seq, &size)) {
+      if (GEOSCoordSeq_getSize(coord_seq, &size)) {
         result = rb_ary_new2(size);
         for (i = 0; i < size; ++i) {
           point = get_point_from_coordseq(self, coord_seq, i, has_z);
@@ -244,7 +234,7 @@ method_line_string_end_point(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    n = GEOSGetNumCoordinates_r(self_data->geos_context, self_geom);
+    n = GEOSGetNumCoordinates(self_geom);
     if (n > 0) {
       result = method_line_string_point_n(self, INT2NUM(n - 1));
     }
@@ -270,7 +260,7 @@ method_line_string_project_point(VALUE self, VALUE point)
   if (self_geom && point) {
     geos_point =
       rgeo_convert_to_geos_geometry(factory, point, rgeo_geos_point_class);
-    location = GEOSProject_r(self_data->geos_context, self_geom, geos_point);
+    location = GEOSProject(self_geom, geos_point);
     result = DBL2NUM(location);
   }
   return result;
@@ -293,8 +283,7 @@ method_line_string_interpolate_point(VALUE self, VALUE loc_num)
   self_geom = self_data->geom;
 
   if (self_geom) {
-    geos_point =
-      GEOSInterpolate_r(self_data->geos_context, self_geom, location);
+    geos_point = GEOSInterpolate(self_geom, location);
     result =
       rgeo_wrap_geos_geometry(factory, geos_point, rgeo_geos_point_class);
   }
@@ -313,8 +302,7 @@ method_line_string_is_closed(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    result =
-      rgeo_is_geos_line_string_closed(self_data->geos_context, self_geom);
+    result = rgeo_is_geos_line_string_closed(self_geom);
   }
   return result;
 }
@@ -331,7 +319,7 @@ method_line_string_is_ring(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    val = GEOSisRing_r(self_data->geos_context, self_geom);
+    val = GEOSisRing(self_geom);
     if (val == 0) {
       result = Qfalse;
     } else if (val == 1) {
@@ -350,8 +338,7 @@ method_line_string_eql(VALUE self, VALUE rhs)
   result = rgeo_geos_klasses_and_factories_eql(self, rhs);
   if (RTEST(result)) {
     self_data = RGEO_GEOMETRY_DATA_PTR(self);
-    result = rgeo_geos_geometries_strict_eql(self_data->geos_context,
-                                             self_data->geom,
+    result = rgeo_geos_geometries_strict_eql(self_data->geom,
                                              RGEO_GEOMETRY_DATA_PTR(rhs)->geom);
   }
   return result;
@@ -368,8 +355,7 @@ method_line_string_hash(VALUE self)
   factory = self_data->factory;
   hash = rb_hash_start(0);
   hash = rgeo_geos_objbase_hash(factory, rgeo_feature_line_string_module, hash);
-  hash =
-    rgeo_geos_coordseq_hash(self_data->geos_context, self_data->geom, hash);
+  hash = rgeo_geos_coordseq_hash(self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
 
@@ -384,8 +370,7 @@ method_linear_ring_hash(VALUE self)
   factory = self_data->factory;
   hash = rb_hash_start(0);
   hash = rgeo_geos_objbase_hash(factory, rgeo_feature_linear_ring_module, hash);
-  hash =
-    rgeo_geos_coordseq_hash(self_data->geos_context, self_data->geom, hash);
+  hash = rgeo_geos_coordseq_hash(self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
 
@@ -400,8 +385,7 @@ method_line_hash(VALUE self)
   factory = self_data->factory;
   hash = rb_hash_start(0);
   hash = rgeo_geos_objbase_hash(factory, rgeo_feature_line_module, hash);
-  hash =
-    rgeo_geos_coordseq_hash(self_data->geos_context, self_data->geom, hash);
+  hash = rgeo_geos_coordseq_hash(self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
 
@@ -414,7 +398,6 @@ coord_seq_from_array(VALUE factory, VALUE array, char close)
   char has_z;
   unsigned int dims;
   double* coords;
-  GEOSContextHandle_t context;
   unsigned int i;
   char good;
   const GEOSGeometry* entry_geom;
@@ -433,21 +416,20 @@ coord_seq_from_array(VALUE factory, VALUE array, char close)
   if (!coords) {
     return NULL;
   }
-  context = factory_data->geos_context;
   for (i = 0; i < len; ++i) {
     good = 0;
     entry_geom = rgeo_convert_to_geos_geometry(
       factory, rb_ary_entry(array, i), point_type);
     if (entry_geom) {
-      entry_cs = GEOSGeom_getCoordSeq_r(context, entry_geom);
+      entry_cs = GEOSGeom_getCoordSeq(entry_geom);
       if (entry_cs) {
-        if (GEOSCoordSeq_getX_r(context, entry_cs, 0, &x)) {
+        if (GEOSCoordSeq_getX(entry_cs, 0, &x)) {
           coords[i * dims] = x;
-          if (GEOSCoordSeq_getY_r(context, entry_cs, 0, &x)) {
+          if (GEOSCoordSeq_getY(entry_cs, 0, &x)) {
             coords[i * dims + 1] = x;
             good = 1;
             if (has_z) {
-              if (GEOSCoordSeq_getZ_r(context, entry_cs, 0, &x)) {
+              if (GEOSCoordSeq_getZ(entry_cs, 0, &x)) {
                 coords[i * dims + 2] = x;
               } else {
                 good = 0;
@@ -470,18 +452,17 @@ coord_seq_from_array(VALUE factory, VALUE array, char close)
   } else {
     close = 0;
   }
-  coord_seq = GEOSCoordSeq_create_r(context, len + close, 3);
+  coord_seq = GEOSCoordSeq_create(len + close, 3);
   if (coord_seq) {
     for (i = 0; i < len; ++i) {
-      GEOSCoordSeq_setX_r(context, coord_seq, i, coords[i * dims]);
-      GEOSCoordSeq_setY_r(context, coord_seq, i, coords[i * dims + 1]);
-      GEOSCoordSeq_setZ_r(
-        context, coord_seq, i, has_z ? coords[i * dims + 2] : 0);
+      GEOSCoordSeq_setX(coord_seq, i, coords[i * dims]);
+      GEOSCoordSeq_setY(coord_seq, i, coords[i * dims + 1]);
+      GEOSCoordSeq_setZ(coord_seq, i, has_z ? coords[i * dims + 2] : 0);
     }
     if (close) {
-      GEOSCoordSeq_setX_r(context, coord_seq, len, coords[0]);
-      GEOSCoordSeq_setY_r(context, coord_seq, len, coords[1]);
-      GEOSCoordSeq_setZ_r(context, coord_seq, len, has_z ? coords[2] : 0);
+      GEOSCoordSeq_setX(coord_seq, len, coords[0]);
+      GEOSCoordSeq_setY(coord_seq, len, coords[1]);
+      GEOSCoordSeq_setZ(coord_seq, len, has_z ? coords[2] : 0);
     }
   }
   FREE(coords);
@@ -500,7 +481,7 @@ cmethod_create_line_string(VALUE module, VALUE factory, VALUE array)
   coord_seq = coord_seq_from_array(factory, array, 0);
   if (coord_seq) {
     factory_data = RGEO_FACTORY_DATA_PTR(factory);
-    geom = GEOSGeom_createLineString_r(factory_data->geos_context, coord_seq);
+    geom = GEOSGeom_createLineString(coord_seq);
     if (geom) {
       result =
         rgeo_wrap_geos_geometry(factory, geom, rgeo_geos_line_string_class);
@@ -521,7 +502,7 @@ cmethod_create_linear_ring(VALUE module, VALUE factory, VALUE array)
   coord_seq = coord_seq_from_array(factory, array, 1);
   if (coord_seq) {
     factory_data = RGEO_FACTORY_DATA_PTR(factory);
-    geom = GEOSGeom_createLinearRing_r(factory_data->geos_context, coord_seq);
+    geom = GEOSGeom_createLinearRing(coord_seq);
     if (geom) {
       result =
         rgeo_wrap_geos_geometry(factory, geom, rgeo_geos_linear_ring_class);
@@ -531,8 +512,7 @@ cmethod_create_linear_ring(VALUE module, VALUE factory, VALUE array)
 }
 
 static void
-populate_geom_into_coord_seq(GEOSContextHandle_t context,
-                             const GEOSGeometry* geom,
+populate_geom_into_coord_seq(const GEOSGeometry* geom,
                              GEOSCoordSequence* coord_seq,
                              unsigned int i,
                              char has_z)
@@ -540,22 +520,22 @@ populate_geom_into_coord_seq(GEOSContextHandle_t context,
   const GEOSCoordSequence* cs;
   double x;
 
-  cs = GEOSGeom_getCoordSeq_r(context, geom);
+  cs = GEOSGeom_getCoordSeq(geom);
   x = 0;
   if (cs) {
-    GEOSCoordSeq_getX_r(context, cs, 0, &x);
+    GEOSCoordSeq_getX(cs, 0, &x);
   }
-  GEOSCoordSeq_setX_r(context, coord_seq, i, x);
+  GEOSCoordSeq_setX(coord_seq, i, x);
   x = 0;
   if (cs) {
-    GEOSCoordSeq_getY_r(context, cs, 0, &x);
+    GEOSCoordSeq_getY(cs, 0, &x);
   }
-  GEOSCoordSeq_setY_r(context, coord_seq, i, x);
+  GEOSCoordSeq_setY(coord_seq, i, x);
   x = 0;
   if (has_z && cs) {
-    GEOSCoordSeq_getZ_r(context, cs, 0, &x);
+    GEOSCoordSeq_getZ(cs, 0, &x);
   }
-  GEOSCoordSeq_setZ_r(context, coord_seq, i, x);
+  GEOSCoordSeq_setZ(coord_seq, i, x);
 }
 
 static VALUE
@@ -565,7 +545,6 @@ cmethod_create_line(VALUE module, VALUE factory, VALUE start, VALUE end)
   RGeo_FactoryData* factory_data;
   char has_z;
   VALUE point_type;
-  GEOSContextHandle_t context;
   const GEOSGeometry* start_geom;
   const GEOSGeometry* end_geom;
   GEOSCoordSequence* coord_seq;
@@ -575,17 +554,16 @@ cmethod_create_line(VALUE module, VALUE factory, VALUE start, VALUE end)
   factory_data = RGEO_FACTORY_DATA_PTR(factory);
   has_z = (char)(factory_data->flags & RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M);
   point_type = rgeo_feature_point_module;
-  context = factory_data->geos_context;
 
   start_geom = rgeo_convert_to_geos_geometry(factory, start, point_type);
   if (start_geom) {
     end_geom = rgeo_convert_to_geos_geometry(factory, end, point_type);
     if (end_geom) {
-      coord_seq = GEOSCoordSeq_create_r(context, 2, 3);
+      coord_seq = GEOSCoordSeq_create(2, 3);
       if (coord_seq) {
-        populate_geom_into_coord_seq(context, start_geom, coord_seq, 0, has_z);
-        populate_geom_into_coord_seq(context, end_geom, coord_seq, 1, has_z);
-        geom = GEOSGeom_createLineString_r(context, coord_seq);
+        populate_geom_into_coord_seq(start_geom, coord_seq, 0, has_z);
+        populate_geom_into_coord_seq(end_geom, coord_seq, 1, has_z);
+        geom = GEOSGeom_createLineString(coord_seq);
         if (geom) {
           result = rgeo_wrap_geos_geometry(factory, geom, rgeo_geos_line_class);
         }
@@ -601,7 +579,6 @@ impl_copy_from(VALUE klass, VALUE factory, VALUE original, char subtype)
 {
   VALUE result;
   const GEOSGeometry* original_geom;
-  GEOSContextHandle_t context;
   const GEOSCoordSequence* original_coord_seq;
   GEOSCoordSequence* coord_seq;
   GEOSGeometry* geom;
@@ -609,17 +586,16 @@ impl_copy_from(VALUE klass, VALUE factory, VALUE original, char subtype)
   result = Qnil;
   original_geom = RGEO_GEOMETRY_DATA_PTR(original)->geom;
   if (original_geom) {
-    context = RGEO_FACTORY_DATA_PTR(factory)->geos_context;
-    if (subtype == 1 && GEOSGetNumCoordinates_r(context, original_geom) != 2) {
+    if (subtype == 1 && GEOSGetNumCoordinates(original_geom) != 2) {
       original_geom = NULL;
     }
     if (original_geom) {
-      original_coord_seq = GEOSGeom_getCoordSeq_r(context, original_geom);
+      original_coord_seq = GEOSGeom_getCoordSeq(original_geom);
       if (original_coord_seq) {
-        coord_seq = GEOSCoordSeq_clone_r(context, original_coord_seq);
+        coord_seq = GEOSCoordSeq_clone(original_coord_seq);
         if (coord_seq) {
-          geom = subtype == 2 ? GEOSGeom_createLinearRing_r(context, coord_seq)
-                              : GEOSGeom_createLineString_r(context, coord_seq);
+          geom = subtype == 2 ? GEOSGeom_createLinearRing(coord_seq)
+                              : GEOSGeom_createLineString(coord_seq);
           if (geom) {
             result = rgeo_wrap_geos_geometry(factory, geom, klass);
           }
@@ -735,8 +711,7 @@ rgeo_init_geos_line_string()
 }
 
 VALUE
-rgeo_is_geos_line_string_closed(GEOSContextHandle_t context,
-                                const GEOSGeometry* geom)
+rgeo_is_geos_line_string_closed(const GEOSGeometry* geom)
 {
   VALUE result;
   unsigned int n;
@@ -744,14 +719,14 @@ rgeo_is_geos_line_string_closed(GEOSContextHandle_t context,
   const GEOSCoordSequence* coord_seq;
 
   result = Qnil;
-  n = GEOSGetNumCoordinates_r(context, geom);
+  n = GEOSGetNumCoordinates(geom);
   if (n > 0) {
-    coord_seq = GEOSGeom_getCoordSeq_r(context, geom);
-    if (GEOSCoordSeq_getX_r(context, coord_seq, 0, &x1)) {
-      if (GEOSCoordSeq_getX_r(context, coord_seq, n - 1, &x2)) {
+    coord_seq = GEOSGeom_getCoordSeq(geom);
+    if (GEOSCoordSeq_getX(coord_seq, 0, &x1)) {
+      if (GEOSCoordSeq_getX(coord_seq, n - 1, &x2)) {
         if (x1 == x2) {
-          if (GEOSCoordSeq_getY_r(context, coord_seq, 0, &y1)) {
-            if (GEOSCoordSeq_getY_r(context, coord_seq, n - 1, &y2)) {
+          if (GEOSCoordSeq_getY(coord_seq, 0, &y1)) {
+            if (GEOSCoordSeq_getY(coord_seq, n - 1, &y2)) {
               result = y1 == y2 ? Qtrue : Qfalse;
             }
           }

--- a/ext/geos_c_impl/line_string.h
+++ b/ext/geos_c_impl/line_string.h
@@ -22,8 +22,7 @@ rgeo_init_geos_line_string();
   Returns Qtrue if true, Qfalse if false, or Qnil on an error.
 */
 VALUE
-rgeo_is_geos_line_string_closed(GEOSContextHandle_t context,
-                                const GEOSGeometry* geom);
+rgeo_is_geos_line_string_closed(const GEOSGeometry* geom);
 
 RGEO_END_C
 

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -27,8 +27,7 @@ method_polygon_eql(VALUE self, VALUE rhs)
   result = rgeo_geos_klasses_and_factories_eql(self, rhs);
   if (RTEST(result)) {
     self_data = RGEO_GEOMETRY_DATA_PTR(self);
-    result = rgeo_geos_geometries_strict_eql(self_data->geos_context,
-                                             self_data->geom,
+    result = rgeo_geos_geometries_strict_eql(self_data->geom,
                                              RGEO_GEOMETRY_DATA_PTR(rhs)->geom);
   }
   return result;
@@ -45,7 +44,7 @@ method_polygon_hash(VALUE self)
   factory = self_data->factory;
   hash = rb_hash_start(0);
   hash = rgeo_geos_objbase_hash(factory, rgeo_feature_polygon_module, hash);
-  hash = rgeo_geos_polygon_hash(self_data->geos_context, self_data->geom, hash);
+  hash = rgeo_geos_polygon_hash(self_data->geom, hash);
   return LONG2FIX(rb_hash_end(hash));
 }
 
@@ -75,7 +74,7 @@ method_polygon_area(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    if (GEOSArea_r(self_data->geos_context, self_geom, &area)) {
+    if (GEOSArea(self_geom, &area)) {
       result = rb_float_new(area);
     }
   }
@@ -94,9 +93,7 @@ method_polygon_centroid(VALUE self)
   self_geom = self_data->geom;
   if (self_geom) {
     result = rgeo_wrap_geos_geometry(
-      self_data->factory,
-      GEOSGetCentroid_r(self_data->geos_context, self_geom),
-      rgeo_geos_point_class);
+      self_data->factory, GEOSGetCentroid(self_geom), rgeo_geos_point_class);
   }
   return result;
 }
@@ -113,9 +110,7 @@ method_polygon_point_on_surface(VALUE self)
   self_geom = self_data->geom;
   if (self_geom) {
     result = rgeo_wrap_geos_geometry(
-      self_data->factory,
-      GEOSPointOnSurface_r(self_data->geos_context, self_geom),
-      rgeo_geos_point_class);
+      self_data->factory, GEOSPointOnSurface(self_geom), rgeo_geos_point_class);
   }
   return result;
 }
@@ -126,7 +121,6 @@ method_polygon_coordinates(VALUE self)
   VALUE result = Qnil;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t self_context;
 
   int zCoordinate;
 
@@ -136,8 +130,7 @@ method_polygon_coordinates(VALUE self)
   if (self_geom) {
     zCoordinate = RGEO_FACTORY_DATA_PTR(self_data->factory)->flags &
                   RGEO_FACTORYFLAGS_SUPPORTS_Z_OR_M;
-    self_context = self_data->geos_context;
-    result = extract_points_from_polygon(self_context, self_geom, zCoordinate);
+    result = extract_points_from_polygon(self_geom, zCoordinate);
   }
   return result;
 }
@@ -153,10 +146,9 @@ method_polygon_exterior_ring(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    result = rgeo_wrap_geos_geometry_clone(
-      self_data->factory,
-      GEOSGetExteriorRing_r(self_data->geos_context, self_geom),
-      rgeo_geos_linear_ring_class);
+    result = rgeo_wrap_geos_geometry_clone(self_data->factory,
+                                           GEOSGetExteriorRing(self_geom),
+                                           rgeo_geos_linear_ring_class);
   }
   return result;
 }
@@ -173,7 +165,7 @@ method_polygon_num_interior_rings(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    num = GEOSGetNumInteriorRings_r(self_data->geos_context, self_geom);
+    num = GEOSGetNumInteriorRings(self_geom);
     if (num >= 0) {
       result = INT2NUM(num);
     }
@@ -188,7 +180,6 @@ method_polygon_interior_ring_n(VALUE self, VALUE n)
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
   int i;
-  GEOSContextHandle_t self_context;
   int num;
 
   result = Qnil;
@@ -197,13 +188,12 @@ method_polygon_interior_ring_n(VALUE self, VALUE n)
   if (self_geom) {
     i = RB_NUM2INT(n);
     if (i >= 0) {
-      self_context = self_data->geos_context;
-      num = GEOSGetNumInteriorRings_r(self_context, self_geom);
+      num = GEOSGetNumInteriorRings(self_geom);
       if (i < num) {
-        result = rgeo_wrap_geos_geometry_clone(
-          self_data->factory,
-          GEOSGetInteriorRingN_r(self_context, self_geom, i),
-          rgeo_geos_linear_ring_class);
+        result =
+          rgeo_wrap_geos_geometry_clone(self_data->factory,
+                                        GEOSGetInteriorRingN(self_geom, i),
+                                        rgeo_geos_linear_ring_class);
       }
     }
   }
@@ -216,7 +206,6 @@ method_polygon_interior_rings(VALUE self)
   VALUE result;
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
-  GEOSContextHandle_t self_context;
   int count;
   VALUE factory;
   int i;
@@ -225,18 +214,17 @@ method_polygon_interior_rings(VALUE self)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    self_context = self_data->geos_context;
-    count = GEOSGetNumInteriorRings_r(self_context, self_geom);
+    count = GEOSGetNumInteriorRings(self_geom);
     if (count >= 0) {
       result = rb_ary_new2(count);
       factory = self_data->factory;
       for (i = 0; i < count; ++i) {
-        rb_ary_store(result,
-                     i,
-                     rgeo_wrap_geos_geometry_clone(
-                       factory,
-                       GEOSGetInteriorRingN_r(self_context, self_geom, i),
-                       rgeo_geos_linear_ring_class));
+        rb_ary_store(
+          result,
+          i,
+          rgeo_wrap_geos_geometry_clone(factory,
+                                        GEOSGetInteriorRingN(self_geom, i),
+                                        rgeo_geos_linear_ring_class));
       }
     }
   }
@@ -252,7 +240,6 @@ cmethod_create(VALUE module,
   RGeo_FactoryData* factory_data;
   VALUE linear_ring_type;
   GEOSGeometry* exterior_geom;
-  GEOSContextHandle_t context;
   unsigned int len;
   GEOSGeometry** interior_geoms;
   unsigned int actual_len;
@@ -273,7 +260,6 @@ cmethod_create(VALUE module,
     return Qnil;
   }
 
-  context = factory_data->geos_context;
   len = (unsigned int)RARRAY_LEN(interior_array);
   interior_geoms = ALLOC_N(GEOSGeometry*, len == 0 ? 1 : len);
   if (interior_geoms) {
@@ -293,8 +279,8 @@ cmethod_create(VALUE module,
       }
     }
     if (len == actual_len) {
-      polygon = GEOSGeom_createPolygon_r(
-        context, exterior_geom, interior_geoms, actual_len);
+      polygon =
+        GEOSGeom_createPolygon(exterior_geom, interior_geoms, actual_len);
       if (polygon) {
         FREE(interior_geoms);
         // NOTE: we can return safely here, state cannot be other than 0.
@@ -303,11 +289,11 @@ cmethod_create(VALUE module,
       }
     }
     for (i = 0; i < actual_len; ++i) {
-      GEOSGeom_destroy_r(context, interior_geoms[i]);
+      GEOSGeom_destroy(interior_geoms[i]);
     }
     FREE(interior_geoms);
   }
-  GEOSGeom_destroy_r(context, exterior_geom);
+  GEOSGeom_destroy(exterior_geom);
   if (state) {
     rb_exc_raise(rb_errinfo());
   }
@@ -353,20 +339,16 @@ rgeo_init_geos_polygon()
 }
 
 st_index_t
-rgeo_geos_polygon_hash(GEOSContextHandle_t context,
-                       const GEOSGeometry* geom,
-                       st_index_t hash)
+rgeo_geos_polygon_hash(const GEOSGeometry* geom, st_index_t hash)
 {
   unsigned int len;
   unsigned int i;
 
   if (geom) {
-    hash = rgeo_geos_coordseq_hash(
-      context, GEOSGetExteriorRing_r(context, geom), hash);
-    len = GEOSGetNumInteriorRings_r(context, geom);
+    hash = rgeo_geos_coordseq_hash(GEOSGetExteriorRing(geom), hash);
+    len = GEOSGetNumInteriorRings(geom);
     for (i = 0; i < len; ++i) {
-      hash = rgeo_geos_coordseq_hash(
-        context, GEOSGetInteriorRingN_r(context, geom, i), hash);
+      hash = rgeo_geos_coordseq_hash(GEOSGetInteriorRingN(geom, i), hash);
     }
   }
   return hash;

--- a/ext/geos_c_impl/polygon.h
+++ b/ext/geos_c_impl/polygon.h
@@ -24,22 +24,19 @@ rgeo_init_geos_polygon();
   Qnil if an error occurs.
 */
 VALUE
-rgeo_geos_polygons_eql(GEOSContextHandle_t context,
-                       const GEOSGeometry* geom1,
+rgeo_geos_polygons_eql(const GEOSGeometry* geom1,
                        const GEOSGeometry* geom2,
                        char check_z);
 
 /*
   A tool for building up hash values.
-  You must pass in the context, a geos geometry, and a seed hash.
+  You must pass in a geos geometry, and a seed hash.
   Returns an updated hash.
   This call is useful in sequence, and should be bracketed by calls to
   rb_hash_start and rb_hash_end.
 */
 st_index_t
-rgeo_geos_polygon_hash(GEOSContextHandle_t context,
-                       const GEOSGeometry* geom,
-                       st_index_t hash);
+rgeo_geos_polygon_hash(const GEOSGeometry* geom, st_index_t hash);
 
 RGEO_END_C
 


### PR DESCRIPTION
We could use only one geos handle since we are running in ruby, and our threads are protected by the GIL. 

This doesn't really improve performances though:

```bash
$ hyperfine \
	--prepare 'git checkout {tag}; rake compile' \
	--parameter-list tag main,one-factory \
	'TEST="test/geos_capi/*test.rb" rake test # {tag}'

Benchmark 1: TEST="test/geos_capi/*test.rb" rake test # main
  Time (mean ± σ):     894.6 ms ±  19.4 ms    [User: 623.4 ms, System: 201.7 ms]
  Range (min … max):   879.4 ms … 947.1 ms    10 runs
 
Benchmark 2: TEST="test/geos_capi/*test.rb" rake test # one-factory
  Time (mean ± σ):     894.0 ms ±  19.4 ms    [User: 629.0 ms, System: 197.8 ms]
  Range (min … max):   870.6 ms … 932.7 ms    10 runs
 
Summary
  'TEST="test/geos_capi/*test.rb" rake test # one-factory' ran
    1.00 ± 0.03 times faster than 'TEST="test/geos_capi/*test.rb" rake test # main'
```