### PR TITLE
Raise Error After Failed Cast in GEOS Impls

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+### Current
+
+**Breaking Changes**
+
+* GEOS and FFI implementations will raise errors instead of returning `nil` when invalid data is given to methods that expect an RGeo geometry. (#341)
+
 ### 3.0.0-rc.3 / 2022-10-11
 
 **Breaking Changes**

--- a/ext/geos_c_impl/factory.c
+++ b/ext/geos_c_impl/factory.c
@@ -833,7 +833,7 @@ rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALUE type, int* state)
   }
   if (NIL_P(object)) {
     rb_protect(
-      rb_exc_raise,
+      rb_exc_raise_value,
       rb_exc_new_cstr(rb_eRGeoInvalidGeometry,
                       "Unable to cast the geometry to the GEOS Factory"),
       state);
@@ -843,7 +843,12 @@ rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALUE type, int* state)
     return NULL;
   }
 
-  rb_protect(rgeo_check_geos_object, object, state);
+  if (!rgeo_is_geos_object(object)) {
+    rb_protect(rb_exc_raise_value,
+               rb_exc_new_cstr(rb_eRGeoError, "Not a GEOS Geometry object."),
+               state);
+  }
+
   if (*state) {
     return NULL;
   }
@@ -879,7 +884,7 @@ rgeo_convert_to_detached_geos_geometry(VALUE obj,
 
   if (NIL_P(object)) {
     rb_protect(
-      rb_exc_raise,
+      rb_exc_raise_value,
       rb_exc_new_cstr(rb_eRGeoInvalidGeometry,
                       "Unable to cast the geometry to the GEOS Factory"),
       state);
@@ -888,7 +893,11 @@ rgeo_convert_to_detached_geos_geometry(VALUE obj,
     return NULL;
   }
 
-  rb_protect(rgeo_check_geos_object, object, state);
+  if (!rgeo_is_geos_object(object)) {
+    rb_protect(rb_exc_raise_value,
+               rb_exc_new_cstr(rb_eRGeoError, "Not a GEOS Geometry object."),
+               state);
+  }
   if (*state) {
     return NULL;
   }

--- a/ext/geos_c_impl/factory.c
+++ b/ext/geos_c_impl/factory.c
@@ -832,7 +832,8 @@ rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALUE type)
       rb_funcall(rgeo_feature_module, rb_intern("cast"), 3, obj, factory, type);
   }
   if (NIL_P(object))
-    return NULL;
+    rb_raise(rb_eRGeoInvalidGeometry,
+             "Unable to cast the geometry to the GEOS Factory");
 
   Check_TypedStruct(object, &rgeo_geometry_type);
   return RGEO_GEOMETRY_DATA_PTR(object)->geom;
@@ -863,9 +864,11 @@ rgeo_convert_to_detached_geos_geometry(VALUE obj,
                               ID2SYM(rb_intern("force_new")),
                               ID2SYM(rb_intern("keep_subtype")));
   if (*state || NIL_P(object)) {
-    return NULL;
+    rb_raise(rb_eRGeoInvalidGeometry,
+             "Unable to cast the geometry to the GEOS Factory");
   }
 
+  Check_TypedStruct(object, &rgeo_geometry_type);
   object_data = RGEO_GEOMETRY_DATA_PTR(object);
   geom = object_data->geom;
   if (klasses) {

--- a/ext/geos_c_impl/factory.c
+++ b/ext/geos_c_impl/factory.c
@@ -823,7 +823,6 @@ const GEOSGeometry*
 rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALUE type, int* state)
 {
   VALUE object;
-  VALUE msg;
 
   if (NIL_P(type) && RGEO_GEOMETRY_TYPEDDATA_P(obj) &&
       RGEO_GEOMETRY_DATA_PTR(obj)->factory == factory) {
@@ -833,9 +832,11 @@ rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALUE type, int* state)
       rb_funcall(rgeo_feature_module, rb_intern("cast"), 3, obj, factory, type);
   }
   if (NIL_P(object)) {
-    msg = rb_str_new_cstr("Unable to cast the geometry to the GEOS Factory");
     rb_protect(
-      rb_exc_raise, rb_exc_new_str(rb_eRGeoInvalidGeometry, msg), state);
+      rb_exc_raise,
+      rb_exc_new_cstr(rb_eRGeoInvalidGeometry,
+                      "Unable to cast the geometry to the GEOS Factory"),
+      state);
   }
 
   if (*state) {
@@ -861,7 +862,6 @@ rgeo_convert_to_detached_geos_geometry(VALUE obj,
   GEOSGeometry* geom;
   RGeo_GeometryData* object_data;
   const GEOSPreparedGeometry* prep;
-  VALUE msg;
 
   if (klasses) {
     *klasses = Qnil;
@@ -878,9 +878,11 @@ rgeo_convert_to_detached_geos_geometry(VALUE obj,
                               ID2SYM(rb_intern("keep_subtype")));
 
   if (NIL_P(object)) {
-    msg = rb_str_new_cstr("Unable to cast the geometry to the GEOS Factory");
     rb_protect(
-      rb_exc_raise, rb_exc_new_str(rb_eRGeoInvalidGeometry, msg), state);
+      rb_exc_raise,
+      rb_exc_new_cstr(rb_eRGeoInvalidGeometry,
+                      "Unable to cast the geometry to the GEOS Factory"),
+      state);
   }
   if (*state) {
     return NULL;

--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -154,6 +154,15 @@ rgeo_wrap_geos_geometry_clone(VALUE factory,
   specified by an appropriate feature module. Passing Qnil for the type
   disables this auto-cast. The returned GEOS geometry is owned by rgeo,
   and you should not dispose it or take ownership of it yourself.
+
+  The state parameter is given to follow `rb_protect*` ruby methods: this
+  method calls `#cast`, and this call may raise. if it does raise, state
+  will be set to a non-zero value, and you'll have access to the error
+  in `rb_errinfo()`. IT IS THE CALLER'S RESPONSIBILITY TO PROPAGATE THE
+  ERROR. You could also discard the error with `rb_set_errinfo(Qnil)`,
+  this will just ignore the error altogether. The error can be raised
+  with `rb_jump_tag(state)` which is helpful if you need to free data
+  before you raise the error.
 */
 const GEOSGeometry*
 rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALUE type, int* state);
@@ -179,7 +188,9 @@ rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALUE type, int* state);
   will be set to a non-zero value, and you'll have access to the error
   in `rb_errinfo()`. IT IS THE CALLER'S RESPONSIBILITY TO PROPAGATE THE
   ERROR. You could also discard the error with `rb_set_errinfo(Qnil)`,
-  this will just ignore the error altogether.
+  this will just ignore the error altogether. The error can be raised
+  with `rb_jump_tag(state)` which is helpful if you need to free data
+  before you raise the error.
 */
 GEOSGeometry*
 rgeo_convert_to_detached_geos_geometry(VALUE obj,

--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -156,7 +156,7 @@ rgeo_wrap_geos_geometry_clone(VALUE factory,
   and you should not dispose it or take ownership of it yourself.
 */
 const GEOSGeometry*
-rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALUE type);
+rgeo_convert_to_geos_geometry(VALUE factory, VALUE obj, VALUE type, int* state);
 
 /*
   Gets a GEOS geometry for a given ruby Geometry object. You must provide

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -411,7 +411,6 @@ method_geometry_disjoint(VALUE self, VALUE rhs)
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
-  char val;
   int state = 0;
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
   const GEOSPreparedGeometry* prep;
@@ -429,15 +428,10 @@ method_geometry_disjoint(VALUE self, VALUE rhs)
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
     prep = rgeo_request_prepared_geometry(self_data);
     if (prep)
-      val = GEOSPreparedDisjoint(prep, rhs_geom);
+      result = GEOSPreparedDisjoint(prep, rhs_geom) ? Qtrue : Qfalse;
     else
 #endif
-      val = GEOSDisjoint(self_geom, rhs_geom);
-    if (val == 0) {
-      result = Qfalse;
-    } else if (val == 1) {
-      result = Qtrue;
-    }
+      result = GEOSDisjoint(self_geom, rhs_geom) ? Qtrue : Qfalse;
   }
   return result;
 }

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -412,6 +412,7 @@ method_geometry_disjoint(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
   char val;
+  int state = 0;
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
   const GEOSPreparedGeometry* prep;
 #endif
@@ -420,7 +421,11 @@ method_geometry_disjoint(VALUE self, VALUE rhs)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
+    rhs_geom =
+      rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
     prep = rgeo_request_prepared_geometry(self_data);
     if (prep)
@@ -445,6 +450,7 @@ method_geometry_intersects(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
   char val;
+  int state = 0;
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED1
   const GEOSPreparedGeometry* prep;
 #endif
@@ -453,7 +459,11 @@ method_geometry_intersects(VALUE self, VALUE rhs)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
+    rhs_geom =
+      rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED1
     prep = rgeo_request_prepared_geometry(self_data);
     if (prep)
@@ -478,6 +488,7 @@ method_geometry_touches(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
   char val;
+  int state = 0;
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
   const GEOSPreparedGeometry* prep;
 #endif
@@ -486,7 +497,11 @@ method_geometry_touches(VALUE self, VALUE rhs)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
+    rhs_geom =
+      rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
     prep = rgeo_request_prepared_geometry(self_data);
     if (prep)
@@ -511,6 +526,7 @@ method_geometry_crosses(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
   char val;
+  int state = 0;
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
   const GEOSPreparedGeometry* prep;
 #endif
@@ -519,7 +535,11 @@ method_geometry_crosses(VALUE self, VALUE rhs)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
+    rhs_geom =
+      rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
     prep = rgeo_request_prepared_geometry(self_data);
     if (prep)
@@ -544,6 +564,7 @@ method_geometry_within(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
   char val;
+  int state = 0;
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
   const GEOSPreparedGeometry* prep;
 #endif
@@ -552,7 +573,11 @@ method_geometry_within(VALUE self, VALUE rhs)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
+    rhs_geom =
+      rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
     prep = rgeo_request_prepared_geometry(self_data);
     if (prep)
@@ -577,6 +602,7 @@ method_geometry_contains(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
   char val;
+  int state = 0;
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED1
   const GEOSPreparedGeometry* prep;
 #endif
@@ -585,7 +611,11 @@ method_geometry_contains(VALUE self, VALUE rhs)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
+    rhs_geom =
+      rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED1
     prep = rgeo_request_prepared_geometry(self_data);
     if (prep)
@@ -610,6 +640,7 @@ method_geometry_overlaps(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
   char val;
+  int state = 0;
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
   const GEOSPreparedGeometry* prep;
 #endif
@@ -618,7 +649,11 @@ method_geometry_overlaps(VALUE self, VALUE rhs)
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
+    rhs_geom =
+      rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
     prep = rgeo_request_prepared_geometry(self_data);
     if (prep)
@@ -643,12 +678,18 @@ method_geometry_relate(VALUE self, VALUE rhs, VALUE pattern)
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
   char val;
+  int state = 0;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
+    rhs_geom =
+      rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
+
     val = GEOSRelatePattern(self_geom, rhs_geom, StringValuePtr(pattern));
     if (val == 0) {
       result = Qfalse;
@@ -667,12 +708,18 @@ method_geometry_distance(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
   double dist;
+  int state = 0;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
-    rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
+    rhs_geom =
+      rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
+
     if (GEOSDistance(self_geom, rhs_geom, &dist)) {
       result = rb_float_new(dist);
     }
@@ -798,13 +845,18 @@ method_geometry_intersection(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   VALUE factory;
   const GEOSGeometry* rhs_geom;
+  int state = 0;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
     factory = self_data->factory;
-    rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
+    rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
+
     result = rgeo_wrap_geos_geometry(
       factory, GEOSIntersection(self_geom, rhs_geom), Qnil);
   }
@@ -819,13 +871,18 @@ method_geometry_union(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   VALUE factory;
   const GEOSGeometry* rhs_geom;
+  int state = 0;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
     factory = self_data->factory;
-    rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
+    rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
+
     result =
       rgeo_wrap_geos_geometry(factory, GEOSUnion(self_geom, rhs_geom), Qnil);
   }
@@ -858,13 +915,18 @@ method_geometry_difference(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   VALUE factory;
   const GEOSGeometry* rhs_geom;
+  int state = 0;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
     factory = self_data->factory;
-    rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
+    rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
+
     result = rgeo_wrap_geos_geometry(
       factory, GEOSDifference(self_geom, rhs_geom), Qnil);
   }
@@ -879,13 +941,18 @@ method_geometry_sym_difference(VALUE self, VALUE rhs)
   const GEOSGeometry* self_geom;
   VALUE factory;
   const GEOSGeometry* rhs_geom;
+  int state = 0;
 
   result = Qnil;
   self_data = RGEO_GEOMETRY_DATA_PTR(self);
   self_geom = self_data->geom;
   if (self_geom) {
     factory = self_data->factory;
-    rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
+    rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil, &state);
+    if (state) {
+      rb_jump_tag(state);
+    }
+
     result = rgeo_wrap_geos_geometry(
       factory, GEOSSymDifference(self_geom, rhs_geom), Qnil);
   }

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -421,19 +421,17 @@ method_geometry_disjoint(VALUE self, VALUE rhs)
   self_geom = self_data->geom;
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
-    if (rhs_geom) {
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
-      prep = rgeo_request_prepared_geometry(self_data);
-      if (prep)
-        val = GEOSPreparedDisjoint(prep, rhs_geom);
-      else
+    prep = rgeo_request_prepared_geometry(self_data);
+    if (prep)
+      val = GEOSPreparedDisjoint(prep, rhs_geom);
+    else
 #endif
-        val = GEOSDisjoint(self_geom, rhs_geom);
-      if (val == 0) {
-        result = Qfalse;
-      } else if (val == 1) {
-        result = Qtrue;
-      }
+      val = GEOSDisjoint(self_geom, rhs_geom);
+    if (val == 0) {
+      result = Qfalse;
+    } else if (val == 1) {
+      result = Qtrue;
     }
   }
   return result;
@@ -456,19 +454,17 @@ method_geometry_intersects(VALUE self, VALUE rhs)
   self_geom = self_data->geom;
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
-    if (rhs_geom) {
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED1
-      prep = rgeo_request_prepared_geometry(self_data);
-      if (prep)
-        val = GEOSPreparedIntersects(prep, rhs_geom);
-      else
+    prep = rgeo_request_prepared_geometry(self_data);
+    if (prep)
+      val = GEOSPreparedIntersects(prep, rhs_geom);
+    else
 #endif
-        val = GEOSIntersects(self_geom, rhs_geom);
-      if (val == 0) {
-        result = Qfalse;
-      } else if (val == 1) {
-        result = Qtrue;
-      }
+      val = GEOSIntersects(self_geom, rhs_geom);
+    if (val == 0) {
+      result = Qfalse;
+    } else if (val == 1) {
+      result = Qtrue;
     }
   }
   return result;
@@ -491,19 +487,17 @@ method_geometry_touches(VALUE self, VALUE rhs)
   self_geom = self_data->geom;
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
-    if (rhs_geom) {
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
-      prep = rgeo_request_prepared_geometry(self_data);
-      if (prep)
-        val = GEOSPreparedTouches(prep, rhs_geom);
-      else
+    prep = rgeo_request_prepared_geometry(self_data);
+    if (prep)
+      val = GEOSPreparedTouches(prep, rhs_geom);
+    else
 #endif
-        val = GEOSTouches(self_geom, rhs_geom);
-      if (val == 0) {
-        result = Qfalse;
-      } else if (val == 1) {
-        result = Qtrue;
-      }
+      val = GEOSTouches(self_geom, rhs_geom);
+    if (val == 0) {
+      result = Qfalse;
+    } else if (val == 1) {
+      result = Qtrue;
     }
   }
   return result;
@@ -526,19 +520,17 @@ method_geometry_crosses(VALUE self, VALUE rhs)
   self_geom = self_data->geom;
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
-    if (rhs_geom) {
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
-      prep = rgeo_request_prepared_geometry(self_data);
-      if (prep)
-        val = GEOSPreparedCrosses(prep, rhs_geom);
-      else
+    prep = rgeo_request_prepared_geometry(self_data);
+    if (prep)
+      val = GEOSPreparedCrosses(prep, rhs_geom);
+    else
 #endif
-        val = GEOSCrosses(self_geom, rhs_geom);
-      if (val == 0) {
-        result = Qfalse;
-      } else if (val == 1) {
-        result = Qtrue;
-      }
+      val = GEOSCrosses(self_geom, rhs_geom);
+    if (val == 0) {
+      result = Qfalse;
+    } else if (val == 1) {
+      result = Qtrue;
     }
   }
   return result;
@@ -561,19 +553,17 @@ method_geometry_within(VALUE self, VALUE rhs)
   self_geom = self_data->geom;
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
-    if (rhs_geom) {
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
-      prep = rgeo_request_prepared_geometry(self_data);
-      if (prep)
-        val = GEOSPreparedWithin(prep, rhs_geom);
-      else
+    prep = rgeo_request_prepared_geometry(self_data);
+    if (prep)
+      val = GEOSPreparedWithin(prep, rhs_geom);
+    else
 #endif
-        val = GEOSWithin(self_geom, rhs_geom);
-      if (val == 0) {
-        result = Qfalse;
-      } else if (val == 1) {
-        result = Qtrue;
-      }
+      val = GEOSWithin(self_geom, rhs_geom);
+    if (val == 0) {
+      result = Qfalse;
+    } else if (val == 1) {
+      result = Qtrue;
     }
   }
   return result;
@@ -596,19 +586,17 @@ method_geometry_contains(VALUE self, VALUE rhs)
   self_geom = self_data->geom;
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
-    if (rhs_geom) {
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED1
-      prep = rgeo_request_prepared_geometry(self_data);
-      if (prep)
-        val = GEOSPreparedContains(prep, rhs_geom);
-      else
+    prep = rgeo_request_prepared_geometry(self_data);
+    if (prep)
+      val = GEOSPreparedContains(prep, rhs_geom);
+    else
 #endif
-        val = GEOSContains(self_geom, rhs_geom);
-      if (val == 0) {
-        result = Qfalse;
-      } else if (val == 1) {
-        result = Qtrue;
-      }
+      val = GEOSContains(self_geom, rhs_geom);
+    if (val == 0) {
+      result = Qfalse;
+    } else if (val == 1) {
+      result = Qtrue;
     }
   }
   return result;
@@ -631,19 +619,17 @@ method_geometry_overlaps(VALUE self, VALUE rhs)
   self_geom = self_data->geom;
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
-    if (rhs_geom) {
 #ifdef RGEO_GEOS_SUPPORTS_PREPARED2
-      prep = rgeo_request_prepared_geometry(self_data);
-      if (prep)
-        val = GEOSPreparedOverlaps(prep, rhs_geom);
-      else
+    prep = rgeo_request_prepared_geometry(self_data);
+    if (prep)
+      val = GEOSPreparedOverlaps(prep, rhs_geom);
+    else
 #endif
-        val = GEOSOverlaps(self_geom, rhs_geom);
-      if (val == 0) {
-        result = Qfalse;
-      } else if (val == 1) {
-        result = Qtrue;
-      }
+      val = GEOSOverlaps(self_geom, rhs_geom);
+    if (val == 0) {
+      result = Qfalse;
+    } else if (val == 1) {
+      result = Qtrue;
     }
   }
   return result;
@@ -663,13 +649,11 @@ method_geometry_relate(VALUE self, VALUE rhs, VALUE pattern)
   self_geom = self_data->geom;
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
-    if (rhs_geom) {
-      val = GEOSRelatePattern(self_geom, rhs_geom, StringValuePtr(pattern));
-      if (val == 0) {
-        result = Qfalse;
-      } else if (val == 1) {
-        result = Qtrue;
-      }
+    val = GEOSRelatePattern(self_geom, rhs_geom, StringValuePtr(pattern));
+    if (val == 0) {
+      result = Qfalse;
+    } else if (val == 1) {
+      result = Qtrue;
     }
   }
   return result;
@@ -689,10 +673,8 @@ method_geometry_distance(VALUE self, VALUE rhs)
   self_geom = self_data->geom;
   if (self_geom) {
     rhs_geom = rgeo_convert_to_geos_geometry(self_data->factory, rhs, Qnil);
-    if (rhs_geom) {
-      if (GEOSDistance(self_geom, rhs_geom, &dist)) {
-        result = rb_float_new(dist);
-      }
+    if (GEOSDistance(self_geom, rhs_geom, &dist)) {
+      result = rb_float_new(dist);
     }
   }
   return result;
@@ -823,10 +805,8 @@ method_geometry_intersection(VALUE self, VALUE rhs)
   if (self_geom) {
     factory = self_data->factory;
     rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
-    if (rhs_geom) {
-      result = rgeo_wrap_geos_geometry(
-        factory, GEOSIntersection(self_geom, rhs_geom), Qnil);
-    }
+    result = rgeo_wrap_geos_geometry(
+      factory, GEOSIntersection(self_geom, rhs_geom), Qnil);
   }
   return result;
 }
@@ -846,10 +826,8 @@ method_geometry_union(VALUE self, VALUE rhs)
   if (self_geom) {
     factory = self_data->factory;
     rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
-    if (rhs_geom) {
-      result =
-        rgeo_wrap_geos_geometry(factory, GEOSUnion(self_geom, rhs_geom), Qnil);
-    }
+    result =
+      rgeo_wrap_geos_geometry(factory, GEOSUnion(self_geom, rhs_geom), Qnil);
   }
   return result;
 }
@@ -887,10 +865,8 @@ method_geometry_difference(VALUE self, VALUE rhs)
   if (self_geom) {
     factory = self_data->factory;
     rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
-    if (rhs_geom) {
-      result = rgeo_wrap_geos_geometry(
-        factory, GEOSDifference(self_geom, rhs_geom), Qnil);
-    }
+    result = rgeo_wrap_geos_geometry(
+      factory, GEOSDifference(self_geom, rhs_geom), Qnil);
   }
   return result;
 }
@@ -910,10 +886,8 @@ method_geometry_sym_difference(VALUE self, VALUE rhs)
   if (self_geom) {
     factory = self_data->factory;
     rhs_geom = rgeo_convert_to_geos_geometry(factory, rhs, Qnil);
-    if (rhs_geom) {
-      result = rgeo_wrap_geos_geometry(
-        factory, GEOSSymDifference(self_geom, rhs_geom), Qnil);
-    }
+    result = rgeo_wrap_geos_geometry(
+      factory, GEOSSymDifference(self_geom, rhs_geom), Qnil);
   }
   return result;
 }

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -31,7 +31,6 @@ create_geometry_collection(VALUE module, int type, VALUE factory, VALUE array)
   VALUE result;
   unsigned int len;
   GEOSGeometry** geoms;
-  RGeo_FactoryData* factory_data;
   VALUE klass;
   unsigned int i;
   unsigned int j;
@@ -49,7 +48,6 @@ create_geometry_collection(VALUE module, int type, VALUE factory, VALUE array)
     rb_raise(rb_eRGeoError, "not enough memory available");
   }
 
-  factory_data = RGEO_FACTORY_DATA_PTR(factory);
   klasses = Qnil;
   cast_type = Qnil;
   switch (type) {

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -97,7 +97,7 @@ create_geometry_collection(VALUE module, int type, VALUE factory, VALUE array)
   // case, this will be a memory leak.
   FREE(geoms);
   if (state) {
-    rb_exc_raise(rb_errinfo()); // raise $!
+    rb_jump_tag(state);
   }
 
   return result;

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -20,24 +20,6 @@
 
 RGEO_BEGIN_C
 
-struct convert_to_detached_geos_geometry_args
-{
-  VALUE obj;
-  VALUE factory;
-  VALUE type;
-  VALUE* klasses;
-  int* state;
-};
-
-VALUE
-rgeo_convert_to_detached_geos_geometry_wrapper(VALUE args_)
-{
-  struct convert_to_detached_geos_geometry_args* args =
-    (struct convert_to_detached_geos_geometry_args*)args_;
-  return rgeo_convert_to_detached_geos_geometry(
-    args->obj, args->factory, args->type, args->klasses, args->state);
-}
-
 /**** INTERNAL IMPLEMENTATION OF CREATE ****/
 
 // Main implementation of the "create" class method for geometry collections.
@@ -58,8 +40,6 @@ create_geometry_collection(VALUE module, int type, VALUE factory, VALUE array)
   GEOSGeometry* geom;
   GEOSGeometry* collection;
   int state = 0;
-  int detached_geos_geom_state = 0;
-  struct convert_to_detached_geos_geometry_args args;
 
   result = Qnil;
   Check_Type(array, T_ARRAY);
@@ -84,22 +64,14 @@ create_geometry_collection(VALUE module, int type, VALUE factory, VALUE array)
       break;
   }
   for (i = 0; i < len; ++i) {
-    args.obj = rb_ary_entry(array, i);
-    args.factory = factory;
-    args.type = cast_type;
-    args.klasses = &klass;
-    args.state = &state;
-
-    geom = rb_protect(rgeo_convert_to_detached_geos_geometry_wrapper,
-                      (VALUE)&args,
-                      &detached_geos_geom_state);
-
-    if (detached_geos_geom_state) {
+    geom = rgeo_convert_to_detached_geos_geometry(
+      rb_ary_entry(array, i), factory, cast_type, &klass, &state);
+    if (state) {
       for (j = 0; j < i; j++) {
         GEOSGeom_destroy(geoms[j]);
       }
       FREE(geoms);
-      rb_jump_tag(detached_geos_geom_state);
+      rb_jump_tag(state);
     }
 
     geoms[i] = geom;

--- a/ext/geos_c_impl/geometry_collection.c
+++ b/ext/geos_c_impl/geometry_collection.c
@@ -66,9 +66,7 @@ create_geometry_collection(VALUE module, int type, VALUE factory, VALUE array)
   for (i = 0; i < len; ++i) {
     geom = rgeo_convert_to_detached_geos_geometry(
       rb_ary_entry(array, i), factory, cast_type, &klass, &state);
-    if (state || !geom) {
-      break;
-    }
+
     geoms[i] = geom;
     if (!NIL_P(klass) && NIL_P(klasses)) {
       klasses = rb_ary_new2(len);

--- a/ext/geos_c_impl/line_string.c
+++ b/ext/geos_c_impl/line_string.c
@@ -420,20 +420,18 @@ coord_seq_from_array(VALUE factory, VALUE array, char close)
     good = 0;
     entry_geom = rgeo_convert_to_geos_geometry(
       factory, rb_ary_entry(array, i), point_type);
-    if (entry_geom) {
-      entry_cs = GEOSGeom_getCoordSeq(entry_geom);
-      if (entry_cs) {
-        if (GEOSCoordSeq_getX(entry_cs, 0, &x)) {
-          coords[i * dims] = x;
-          if (GEOSCoordSeq_getY(entry_cs, 0, &x)) {
-            coords[i * dims + 1] = x;
-            good = 1;
-            if (has_z) {
-              if (GEOSCoordSeq_getZ(entry_cs, 0, &x)) {
-                coords[i * dims + 2] = x;
-              } else {
-                good = 0;
-              }
+    entry_cs = GEOSGeom_getCoordSeq(entry_geom);
+    if (entry_cs) {
+      if (GEOSCoordSeq_getX(entry_cs, 0, &x)) {
+        coords[i * dims] = x;
+        if (GEOSCoordSeq_getY(entry_cs, 0, &x)) {
+          coords[i * dims + 1] = x;
+          good = 1;
+          if (has_z) {
+            if (GEOSCoordSeq_getZ(entry_cs, 0, &x)) {
+              coords[i * dims + 2] = x;
+            } else {
+              good = 0;
             }
           }
         }
@@ -556,18 +554,14 @@ cmethod_create_line(VALUE module, VALUE factory, VALUE start, VALUE end)
   point_type = rgeo_feature_point_module;
 
   start_geom = rgeo_convert_to_geos_geometry(factory, start, point_type);
-  if (start_geom) {
-    end_geom = rgeo_convert_to_geos_geometry(factory, end, point_type);
-    if (end_geom) {
-      coord_seq = GEOSCoordSeq_create(2, 3);
-      if (coord_seq) {
-        populate_geom_into_coord_seq(start_geom, coord_seq, 0, has_z);
-        populate_geom_into_coord_seq(end_geom, coord_seq, 1, has_z);
-        geom = GEOSGeom_createLineString(coord_seq);
-        if (geom) {
-          result = rgeo_wrap_geos_geometry(factory, geom, rgeo_geos_line_class);
-        }
-      }
+  end_geom = rgeo_convert_to_geos_geometry(factory, end, point_type);
+  coord_seq = GEOSCoordSeq_create(2, 3);
+  if (coord_seq) {
+    populate_geom_into_coord_seq(start_geom, coord_seq, 0, has_z);
+    populate_geom_into_coord_seq(end_geom, coord_seq, 1, has_z);
+    geom = GEOSGeom_createLineString(coord_seq);
+    if (geom) {
+      result = rgeo_wrap_geos_geometry(factory, geom, rgeo_geos_line_class);
     }
   }
 

--- a/ext/geos_c_impl/line_string.c
+++ b/ext/geos_c_impl/line_string.c
@@ -397,7 +397,6 @@ method_line_hash(VALUE self)
 static GEOSCoordSequence*
 coord_seq_from_array(VALUE factory, VALUE array, char close)
 {
-  RGeo_FactoryData* factory_data;
   VALUE point_type;
   unsigned int len;
   char has_z;
@@ -412,7 +411,6 @@ coord_seq_from_array(VALUE factory, VALUE array, char close)
   int state = 0;
 
   Check_Type(array, T_ARRAY);
-  factory_data = RGEO_FACTORY_DATA_PTR(factory);
   point_type = rgeo_feature_point_module;
   len = (unsigned int)RARRAY_LEN(array);
   has_z = (char)(RGEO_FACTORY_DATA_PTR(factory)->flags &
@@ -484,13 +482,11 @@ cmethod_create_line_string(VALUE module, VALUE factory, VALUE array)
 {
   VALUE result;
   GEOSCoordSequence* coord_seq;
-  RGeo_FactoryData* factory_data;
   GEOSGeometry* geom;
 
   result = Qnil;
   coord_seq = coord_seq_from_array(factory, array, 0);
   if (coord_seq) {
-    factory_data = RGEO_FACTORY_DATA_PTR(factory);
     geom = GEOSGeom_createLineString(coord_seq);
     if (geom) {
       result =
@@ -505,13 +501,11 @@ cmethod_create_linear_ring(VALUE module, VALUE factory, VALUE array)
 {
   VALUE result;
   GEOSCoordSequence* coord_seq;
-  RGeo_FactoryData* factory_data;
   GEOSGeometry* geom;
 
   result = Qnil;
   coord_seq = coord_seq_from_array(factory, array, 1);
   if (coord_seq) {
-    factory_data = RGEO_FACTORY_DATA_PTR(factory);
     geom = GEOSGeom_createLinearRing(coord_seq);
     if (geom) {
       result =

--- a/ext/geos_c_impl/point.c
+++ b/ext/geos_c_impl/point.c
@@ -208,12 +208,10 @@ VALUE
 rgeo_create_geos_point(VALUE factory, double x, double y, double z)
 {
   VALUE result;
-  RGeo_FactoryData* factory_data;
   GEOSCoordSequence* coord_seq;
   GEOSGeometry* geom;
 
   result = Qnil;
-  factory_data = RGEO_FACTORY_DATA_PTR(factory);
   coord_seq = GEOSCoordSeq_create(1, 3);
   if (coord_seq) {
     if (GEOSCoordSeq_setX(coord_seq, 0, x)) {

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -253,12 +253,6 @@ cmethod_create(VALUE module,
   linear_ring_type = rgeo_feature_linear_ring_module;
   exterior_geom = rgeo_convert_to_detached_geos_geometry(
     exterior, factory, linear_ring_type, NULL, &state);
-  if (state) {
-    rb_exc_raise(rb_errinfo());
-  }
-  if (!exterior_geom) {
-    return Qnil;
-  }
 
   len = (unsigned int)RARRAY_LEN(interior_array);
   interior_geoms = ALLOC_N(GEOSGeometry*, len == 0 ? 1 : len);
@@ -271,12 +265,7 @@ cmethod_create(VALUE module,
                                                linear_ring_type,
                                                NULL,
                                                &state);
-      if (interior_geom) {
-        interior_geoms[actual_len++] = interior_geom;
-      }
-      if (state) {
-        break;
-      }
+      interior_geoms[actual_len++] = interior_geom;
     }
     if (len == actual_len) {
       polygon =

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -296,7 +296,7 @@ cmethod_create(VALUE module,
   }
   GEOSGeom_destroy(exterior_geom);
   if (state) {
-    rb_exc_raise(rb_errinfo());
+    rb_jump_tag(state);
   }
   return Qnil;
 }

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -237,7 +237,6 @@ cmethod_create(VALUE module,
                VALUE exterior,
                VALUE interior_array)
 {
-  RGeo_FactoryData* factory_data;
   VALUE linear_ring_type;
   GEOSGeometry* exterior_geom;
   unsigned int len;
@@ -250,7 +249,6 @@ cmethod_create(VALUE module,
   int state = 0;
 
   Check_Type(interior_array, T_ARRAY);
-  factory_data = RGEO_FACTORY_DATA_PTR(factory);
   linear_ring_type = rgeo_feature_linear_ring_module;
   exterior_geom = rgeo_convert_to_detached_geos_geometry(
     exterior, factory, linear_ring_type, NULL, &state);

--- a/ext/geos_c_impl/polygon.h
+++ b/ext/geos_c_impl/polygon.h
@@ -18,7 +18,7 @@ void
 rgeo_init_geos_polygon();
 
 /*
-  Comopares the values of two GEOS polygons. The two given geometries MUST
+  Compares the values of two GEOS polygons. The two given geometries MUST
   be polygon types.
   Returns Qtrue if the polygons are equal, Qfalse if they are inequal, or
   Qnil if an error occurs.

--- a/ext/geos_c_impl/ruby_more.c
+++ b/ext/geos_c_impl/ruby_more.c
@@ -55,6 +55,13 @@ rb_protect_funcall(VALUE recv, ID mid, int* state, int n, ...)
   return rb_protect(inner_funcall, (VALUE)&args, state);
 }
 
+VALUE
+rb_exc_raise_value(VALUE exc)
+{
+  rb_exc_raise(exc);
+  return Qnil;
+}
+
 RGEO_END_C
 
 #endif

--- a/ext/geos_c_impl/ruby_more.h
+++ b/ext/geos_c_impl/ruby_more.h
@@ -12,6 +12,11 @@ RGEO_BEGIN_C
 VALUE
 rb_protect_funcall(VALUE recv, ID mid, int* state, int n, ...);
 
+/*
+  Raises an error based on the exception passed in, but also returns
+  a VALUE rather than void. This is so we can pass it into rb_protect
+  without getting type mismatch warnings.
+*/
 VALUE
 rb_exc_raise_value(VALUE exc);
 

--- a/ext/geos_c_impl/ruby_more.h
+++ b/ext/geos_c_impl/ruby_more.h
@@ -12,6 +12,9 @@ RGEO_BEGIN_C
 VALUE
 rb_protect_funcall(VALUE recv, ID mid, int* state, int n, ...);
 
+VALUE
+rb_exc_raise_value(VALUE exc);
+
 RGEO_END_C
 
 #endif

--- a/lib/rgeo/geos/ffi_factory.rb
+++ b/lib/rgeo/geos/ffi_factory.rb
@@ -430,7 +430,7 @@ module RGeo
         end
 
         geom = obj&.fg_geom
-        raise RGeo::Error::GeosError, "Unable to cast the geometry to the FFI Factory" if geom.nil?
+        raise RGeo::Error::InvalidGeometry, "Unable to cast the geometry to the FFI Factory" if geom.nil?
 
         geom
       end

--- a/lib/rgeo/geos/ffi_factory.rb
+++ b/lib/rgeo/geos/ffi_factory.rb
@@ -428,7 +428,11 @@ module RGeo
         if type && obj.factory != self
           obj = Feature.cast(obj, self, type)
         end
-        obj&.fg_geom
+
+        geom = obj&.fg_geom
+        raise RGeo::Error::GeosError, "Unable to cast the geometry to the FFI Factory" if geom.nil?
+
+        geom
       end
 
       def generate_wkt(geom)

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -158,11 +158,10 @@ module RGeo
       def equals?(rhs)
         return false unless rhs.is_a?(RGeo::Feature::Instance)
         fg = factory.convert_to_fg_geometry(rhs)
-        if !fg
-          false
+
         # GEOS has a bug where empty geometries are not spatially equal
         # to each other. Work around this case first.
-        elsif fg.empty? && @fg_geom.empty?
+        if fg.empty? && @fg_geom.empty?
           true
         else
           @fg_geom.eql?(fg)
@@ -172,83 +171,55 @@ module RGeo
 
       def disjoint?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        if fg
-          prep = request_prepared if Utils.ffi_supports_prepared_level_2
-          prep ? prep.disjoint?(fg) : @fg_geom.disjoint?(fg)
-        else
-          false
-        end
+        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep ? prep.disjoint?(fg) : @fg_geom.disjoint?(fg)
       end
 
       def intersects?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        if fg
-          prep = request_prepared if Utils.ffi_supports_prepared_level_1
-          prep ? prep.intersects?(fg) : @fg_geom.intersects?(fg)
-        else
-          false
-        end
+        prep = request_prepared if Utils.ffi_supports_prepared_level_1
+        prep ? prep.intersects?(fg) : @fg_geom.intersects?(fg)
       end
 
       def touches?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        if fg
-          prep = request_prepared if Utils.ffi_supports_prepared_level_2
-          prep ? prep.touches?(fg) : @fg_geom.touches?(fg)
-        else
-          false
-        end
+        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep ? prep.touches?(fg) : @fg_geom.touches?(fg)
       end
 
       def crosses?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        if fg
-          prep = request_prepared if Utils.ffi_supports_prepared_level_2
-          prep ? prep.crosses?(fg) : @fg_geom.crosses?(fg)
-        else
-          false
-        end
+        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep ? prep.crosses?(fg) : @fg_geom.crosses?(fg)
       end
 
       def within?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        if fg
-          prep = request_prepared if Utils.ffi_supports_prepared_level_2
-          prep ? prep.within?(fg) : @fg_geom.within?(fg)
-        else
-          false
-        end
+        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep ? prep.within?(fg) : @fg_geom.within?(fg)
       end
 
       def contains?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        if fg
-          prep = request_prepared if Utils.ffi_supports_prepared_level_1
-          prep ? prep.contains?(fg) : @fg_geom.contains?(fg)
-        else
-          false
-        end
+        prep = request_prepared if Utils.ffi_supports_prepared_level_1
+        prep ? prep.contains?(fg) : @fg_geom.contains?(fg)
       end
 
       def overlaps?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        if fg
-          prep = request_prepared if Utils.ffi_supports_prepared_level_2
-          prep ? prep.overlaps?(fg) : @fg_geom.overlaps?(fg)
-        else
-          false
-        end
+        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep ? prep.overlaps?(fg) : @fg_geom.overlaps?(fg)
       end
 
       def relate?(rhs, pattern)
         fg = factory.convert_to_fg_geometry(rhs)
-        fg ? @fg_geom.relate_pattern(fg, pattern) : nil
+        @fg_geom.relate_pattern(fg, pattern)
       end
       alias relate relate? # DEPRECATED
 
       def distance(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        fg ? @fg_geom.distance(fg) : nil
+        @fg_geom.distance(fg)
       end
 
       def buffer(distance)
@@ -261,14 +232,14 @@ module RGeo
 
       def intersection(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        fg ? @factory.wrap_fg_geom(@fg_geom.intersection(fg), nil) : nil
+        @factory.wrap_fg_geom(@fg_geom.intersection(fg), nil)
       end
 
       alias * intersection
 
       def union(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        fg ? @factory.wrap_fg_geom(@fg_geom.union(fg), nil) : nil
+        @factory.wrap_fg_geom(@fg_geom.union(fg), nil)
       end
 
       alias + union
@@ -280,14 +251,14 @@ module RGeo
 
       def difference(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        fg ? @factory.wrap_fg_geom(@fg_geom.difference(fg), nil) : nil
+        @factory.wrap_fg_geom(@fg_geom.difference(fg), nil)
       end
 
       alias - difference
 
       def sym_difference(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        fg ? @factory.wrap_fg_geom(@fg_geom.sym_difference(fg), nil) : nil
+        @factory.wrap_fg_geom(@fg_geom.sym_difference(fg), nil)
       end
 
       def eql?(rhs)

--- a/test/geos_capi/misc_test.rb
+++ b/test/geos_capi/misc_test.rb
@@ -136,9 +136,23 @@ class GeosMiscTest < Minitest::Test # :nodoc:
   end
 
   def test_casting_dumb_objects
-    assert_raises(TypeError) do
+    assert_raises(RGeo::Error::RGeoError) do
       # We use an OpenStruct here because we want an object that respond `nil` to unknown methods.
       RGeo::Geos.factory.point(1, 1).contains?(OpenStruct.new(factory: RGeo::Geos.factory)) # rubocop:disable Style/OpenStructUse
+    end
+  end
+
+  def test_polygon_creation_invalid_cast
+    assert_raises(RGeo::Error::RGeoError) do
+      fac = RGeo::Geos.factory
+      points = [fac.point(0, 0), fac.point(0, 1), fac.point(1, 1), fac.point(1, 0)]
+      shell = fac.linear_ring(points)
+
+      fake_geom = Struct.new(:factory)
+      hole = fake_geom.new(factory: fac)
+
+      # test that polygon creation will properly free data on a cast error
+      fac.polygon(shell, [shell, hole])
     end
   end
 end if RGeo::Geos.capi_supported?

--- a/test/geos_ffi/misc_test.rb
+++ b/test/geos_ffi/misc_test.rb
@@ -77,6 +77,13 @@ class GeosFFIMiscTest < Minitest::Test # :nodoc:
       assert_equal(nil, geom)
     end
   end
+
+  def test_casting_dumb_objects
+    test_struct = Struct.new(:factory, :fg_geom)
+    assert_raises(RGeo::Error::InvalidGeometry) do
+      @factory.point(1, 1).contains?(test_struct.new(factory: @factory))
+    end
+  end
 end if RGeo::Geos.ffi_supported?
 
 unless RGeo::Geos.ffi_supported?


### PR DESCRIPTION
### Summary

Raise errors instead of returning `nil` when objects cannot be properly cast to GEOS geometries in both the capi and FFI implementations.

These methods are primarily called when a method requires a second geometry (ex. `intersects?` takes a `rhs` argument). So now if invalid data is given in `rhs` an error will be raised. 
