### PR TITLE
fix(FFI,GEOS): hash method for `LineString`

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,11 @@
 
 * Add `transform` method to `Geometry`. #342
 
+**Bug Fixes**
+
+* Fix `#hash` for every `LineString` related classes in FFI and for Z factories
+  in CAPI. #344
+
 ### 3.0.0-rc.3 / 2022-10-11
 
 **Breaking Changes**

--- a/ext/geos_c_impl/factory.c
+++ b/ext/geos_c_impl/factory.c
@@ -1023,7 +1023,7 @@ rgeo_geos_coordseq_hash(const GEOSGeometry* geom, st_index_t hash)
         for (i = 0; i < len; ++i) {
           if (GEOSCoordSeq_getX(cs, i, &hash_struct.x)) {
             if (GEOSCoordSeq_getY(cs, i, &hash_struct.y)) {
-              if (!GEOSCoordSeq_getY(cs, i, &hash_struct.z)) {
+              if (!GEOSCoordSeq_getZ(cs, i, &hash_struct.z)) {
                 hash_struct.z = 0;
               }
               hash_struct.seed_hash = hash;

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -367,7 +367,6 @@ method_geometry_equals(VALUE self, VALUE rhs)
   RGeo_GeometryData* self_data;
   const GEOSGeometry* self_geom;
   const GEOSGeometry* rhs_geom;
-  char val;
 
   // Shortcut when self and rhs are the same object.
   if (self == rhs) {
@@ -385,12 +384,7 @@ method_geometry_equals(VALUE self, VALUE rhs)
       if (GEOSisEmpty(self_geom) == 1 && GEOSisEmpty(rhs_geom) == 1) {
         result = Qtrue;
       } else {
-        val = GEOSEquals(self_geom, rhs_geom);
-        if (val == 0) {
-          result = Qfalse;
-        } else if (val == 1) {
-          result = Qtrue;
-        }
+        result = GEOSEquals(self_geom, rhs_geom) ? Qtrue : Qfalse;
       }
     }
   }

--- a/lib/rgeo/geos/utils.rb
+++ b/lib/rgeo/geos/utils.rb
@@ -49,8 +49,8 @@ module RGeo
           result
         end
 
-        def ffi_coord_seq_hash(cs, hash = 0)
-          (0...cs.length).inject(hash) do |h, i|
+        def ffi_coord_seq_hash(cs, init_hash = 0)
+          (0...cs.length).inject(init_hash) do |hash, i|
             [hash, cs.get_x(i), cs.get_y(i), cs.get_z(i)].hash
           end
         end

--- a/test/common/line_string_tests.rb
+++ b/test/common/line_string_tests.rb
@@ -209,6 +209,24 @@ module RGeo
           refute_equal(line1.hash, line2.hash)
         end
 
+        # Non-regression of a bug.
+        # https://github.com/rgeo/rgeo/pull/338#discussion_r1017066445
+        def test_comparison_line_string
+          point1 = @factory.point(1, 0)
+          point2 = @factory.point(3, 0)
+          ls1 = @factory.line_string([point1, @factory.point(2, 0), point2])
+          ls2 = @factory.line_string([point1, point2])
+
+          # Spacial equivalence
+          if ls1.respond_to?(:equals?) && ls1.method(:equals?).owner != RGeo::Feature::Geometry
+            assert(ls1.equals?(ls2))
+          end
+          # But not representational
+          refute(ls1.rep_equals?(ls2))
+          # And hash should differ as well
+          refute_equal(ls1.hash, ls2.hash)
+        end
+
         def test_wkt_creation
           line1 = @factory.parse_wkt("LINESTRING(21 22, 11 12)")
           assert_equal(@factory.point(21, 22), line1.point_n(0))

--- a/test/geos_ffi/line_string_test.rb
+++ b/test/geos_ffi/line_string_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "../test_helper"
 
 class GeosFFILineStringTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::LineStringTests

--- a/test/simple_mercator/line_string_test.rb
+++ b/test/simple_mercator/line_string_test.rb
@@ -6,7 +6,7 @@
 #
 # -----------------------------------------------------------------------------
 
-require "test_helper"
+require_relative "../test_helper"
 
 class MercatorLineStringTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::LineStringTests


### PR DESCRIPTION
Bug reproduction:

```sh
cat <<-RB | ruby -Ilib -rrgeo
f = RGeo::Geos.factory(native_interface: :ffi)
ls1 = f.line_string([f.point(1, 1), f.point(2, 2), f.point(3, 3)])
ls2 = f.line_string([f.point(1, 1), f.point(3, 3)])

exit 1 if ls1 == ls2
RB
```

Source: https://github.com/rgeo/rgeo/pull/338#discussion_r1017066445
