### PR TITLE
refactor(tests): Use modules to skip GEOS

### DIFF
--- a/test/geos_capi/factory_test.rb
+++ b/test/geos_capi/factory_test.rb
@@ -7,12 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_capi"
 
 class GeosFactoryTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::FactoryTests
+  prepend SkipCAPI
 
   def setup
-    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
     @factory = RGeo::Geos.factory(srid: 1000)
     @srid = 1000
   end

--- a/test/geos_capi/geometry_collection_test.rb
+++ b/test/geos_capi/geometry_collection_test.rb
@@ -7,15 +7,11 @@
 # -----------------------------------------------------------------------------
 
 require_relative "../test_helper"
+require_relative "skip_capi"
 
 class GeosGeometryCollectionTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::GeometryCollectionTests
-
-  def setup
-    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
-
-    super
-  end
+  prepend SkipCAPI
 
   def create_factory
     RGeo::Geos.factory

--- a/test/geos_capi/misc_test.rb
+++ b/test/geos_capi/misc_test.rb
@@ -9,6 +9,7 @@
 require "ostruct"
 require_relative "../test_helper"
 require_relative "../common/validity_tests"
+require_relative "skip_capi"
 
 class GeosMiscTest < Minitest::Test # :nodoc:
   def setup

--- a/test/geos_capi/multi_line_string_test.rb
+++ b/test/geos_capi/multi_line_string_test.rb
@@ -7,15 +7,11 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_capi"
 
 class GeosMultiLineStringTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::MultiLineStringTests
-
-  def setup
-    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
-
-    super
-  end
+  prepend SkipCAPI
 
   def create_factory
     RGeo::Geos.factory

--- a/test/geos_capi/multi_point_test.rb
+++ b/test/geos_capi/multi_point_test.rb
@@ -7,15 +7,11 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_capi"
 
 class GeosMultiPointTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::MultiPointTests
-
-  def setup
-    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
-
-    super
-  end
+  prepend SkipCAPI
 
   def create_factory(opts = {})
     RGeo::Geos.factory(opts)

--- a/test/geos_capi/multi_polygon_test.rb
+++ b/test/geos_capi/multi_polygon_test.rb
@@ -7,15 +7,11 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_capi"
 
 class GeosMultiPolygonTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::MultiPolygonTests
-
-  def setup
-    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
-
-    super
-  end
+  prepend SkipCAPI
 
   def create_factories
     @factory = RGeo::Geos.factory

--- a/test/geos_capi/point_test.rb
+++ b/test/geos_capi/point_test.rb
@@ -7,12 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_capi"
 
 class GeosPointTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::PointTests
+  prepend SkipCAPI
 
   def setup
-    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
     @factory = RGeo::Geos.factory(buffer_resolution: 8)
     @zfactory = RGeo::Geos.factory(has_z_coordinate: true)
     @mfactory = RGeo::Geos.factory(has_m_coordinate: true)

--- a/test/geos_capi/polygon_test.rb
+++ b/test/geos_capi/polygon_test.rb
@@ -7,17 +7,18 @@
 # -----------------------------------------------------------------------------
 
 require_relative "../test_helper"
+require_relative "skip_capi"
 
 class GeosPolygonTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::PolygonTests
+  prepend SkipCAPI
+
+  def setup
+    @factory = RGeo::Geos.factory
+  end
 
   def assert_close_enough(pt1, pt2)
     assert((pt1.x - pt2.x).abs < 0.00000001 && (pt1.y - pt2.y).abs < 0.00000001)
-  end
-
-  def setup
-    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
-    @factory = RGeo::Geos.factory
   end
 
   def test_intersection

--- a/test/geos_capi/skip_capi.rb
+++ b/test/geos_capi/skip_capi.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module SkipCAPI
+  def setup
+    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
+    super
+  end
+end

--- a/test/geos_capi/validity_test.rb
+++ b/test/geos_capi/validity_test.rb
@@ -7,12 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require_relative "../test_helper"
+require_relative "skip_capi"
 
 class GeosValidityTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::ValidityTests
+  prepend SkipCAPI
 
   def setup
-    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
     @factory = RGeo::Geos.factory
   end
 

--- a/test/geos_capi/zmfactory_test.rb
+++ b/test/geos_capi/zmfactory_test.rb
@@ -7,12 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_capi"
 
 class GeosZMFactoryTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::FactoryTests
+  prepend SkipCAPI
 
   def setup
-    skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
     @factory = RGeo::Geos.factory(has_z_coordinate: true, has_m_coordinate: true, srid: 1000, buffer_resolution: 2)
     @srid = 1000
   end

--- a/test/geos_ffi/factory_test.rb
+++ b/test/geos_ffi/factory_test.rb
@@ -7,13 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require_relative "../test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIFactoryTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::FactoryTests
+  include SkipFFI
 
   def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
     @factory = RGeo::Geos.factory(srid: 1000, native_interface: :ffi)
     @srid = 1000
   end

--- a/test/geos_ffi/geometry_collection_test.rb
+++ b/test/geos_ffi/geometry_collection_test.rb
@@ -7,15 +7,11 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIGeometryCollectionTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::GeometryCollectionTests
-
-  def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
-    super
-  end
+  include SkipFFI
 
   def create_factory
     RGeo::Geos.factory(native_interface: :ffi)

--- a/test/geos_ffi/line_string_test.rb
+++ b/test/geos_ffi/line_string_test.rb
@@ -7,13 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require_relative "../test_helper"
+require_relative "skip_ffi"
 
 class GeosFFILineStringTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::LineStringTests
+  include SkipFFI
 
   def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
     @factory = RGeo::Geos.factory(native_interface: :ffi)
   end
 end

--- a/test/geos_ffi/misc_test.rb
+++ b/test/geos_ffi/misc_test.rb
@@ -8,11 +8,12 @@
 
 require_relative "../test_helper"
 require_relative "../common/validity_tests"
+require_relative "skip_ffi"
 
 class GeosFFIMiscTest < Minitest::Test # :nodoc:
-  def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
+  prepend SkipFFI
 
+  def setup
     @factory = RGeo::Geos.factory(srid: 4326, native_interface: :ffi)
   end
 

--- a/test/geos_ffi/multi_line_string_test.rb
+++ b/test/geos_ffi/multi_line_string_test.rb
@@ -7,15 +7,11 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIMultiLineStringTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::MultiLineStringTests
-
-  def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
-    super
-  end
+  include SkipFFI
 
   def create_factory
     RGeo::Geos.factory(native_interface: :ffi)

--- a/test/geos_ffi/multi_point_test.rb
+++ b/test/geos_ffi/multi_point_test.rb
@@ -7,15 +7,11 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIMultiPointTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::MultiPointTests
-
-  def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
-    super
-  end
+  include SkipFFI
 
   def create_factory(opts = {})
     RGeo::Geos.factory(opts.merge(native_interface: :ffi))

--- a/test/geos_ffi/multi_polygon_test.rb
+++ b/test/geos_ffi/multi_polygon_test.rb
@@ -7,15 +7,11 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIMultiPolygonTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::MultiPolygonTests
-
-  def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
-    super
-  end
+  include SkipFFI
 
   def create_factories
     @factory = RGeo::Geos.factory(native_interface: :ffi)

--- a/test/geos_ffi/point_test.rb
+++ b/test/geos_ffi/point_test.rb
@@ -7,13 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIPointTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::PointTests
+  include SkipFFI
 
   def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
     @factory = RGeo::Geos.factory(native_interface: :ffi, buffer_resolution: 8)
     @zfactory = RGeo::Geos.factory(has_z_coordinate: true, native_interface: :ffi)
     @mfactory = RGeo::Geos.factory(has_m_coordinate: true, native_interface: :ffi)

--- a/test/geos_ffi/polygon_test.rb
+++ b/test/geos_ffi/polygon_test.rb
@@ -7,13 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIPolygonTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::PolygonTests
+  include SkipFFI
 
   def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
     @factory = RGeo::Geos.factory(native_interface: :ffi)
   end
 

--- a/test/geos_ffi/skip_ffi.rb
+++ b/test/geos_ffi/skip_ffi.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module SkipFFI
+  def setup
+    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
+    super
+  end
+end

--- a/test/geos_ffi/validity_test.rb
+++ b/test/geos_ffi/validity_test.rb
@@ -7,13 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require_relative "../test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIValidityTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::ValidityTests
+  include SkipFFI
 
   def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
     @factory = RGeo::Geos.factory(native_interface: :ffi)
   end
 end

--- a/test/geos_ffi/wkrep_test.rb
+++ b/test/geos_ffi/wkrep_test.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "../test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIWKREPTest < Minitest::Test
+  include SkipFFI
+
   def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
     @factory = RGeo::Geos.factory(native_interface: :ffi)
   end
 

--- a/test/geos_ffi/zmfactory_test.rb
+++ b/test/geos_ffi/zmfactory_test.rb
@@ -7,13 +7,13 @@
 # -----------------------------------------------------------------------------
 
 require "test_helper"
+require_relative "skip_ffi"
 
 class GeosFFIZMFactoryTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::FactoryTests
+  include SkipFFI
 
   def setup
-    skip "Needs GEOS FFI." unless RGeo::Geos.ffi_supported?
-
     @factory = RGeo::Geos.factory(has_z_coordinate: true, has_m_coordinate: true,
                                   srid: 1000, buffer_resolution: 2, native_interface: :ffi)
     @srid = 1000


### PR DESCRIPTION
This helps changing the behavior quickly, and clarify intents of `setup` methods.
