### PR TITLE
Remove Naming/VariableNumber rubocop offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,21 +27,6 @@ Metrics/BlockNesting:
   Exclude:
     - 'lib/rgeo/feature/types.rb'
 
-# Offense count: 20
-# Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers.
-# SupportedStyles: snake_case, normalcase, non_integer
-# AllowedIdentifiers: capture3, iso8601, rfc1123_date, rfc822, rfc2822, rfc3339
-Naming/VariableNumber:
-  Exclude:
-    - 'lib/rgeo/geographic/interface.rb'
-    - 'lib/rgeo/geographic/simple_mercator_projector.rb'
-    - 'lib/rgeo/geos/utils.rb'
-    - 'test/coord_sys/ogc_cs_test.rb'
-    - 'test/coord_sys/sr_org_test.rb'
-    - 'test/geos_capi/misc_test.rb'
-    - 'test/geos_capi/multi_polygon_test.rb'
-    - 'test/simple_cartesian/point_test.rb'
-
 # Offense count: 60
 Style/Documentation:
   Enabled: false

--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@
 * Add `transform` method to `Geometry`. #342
 * Fix rubocop_todos and other refactoring. (@thestelz) #338
 * Fix Style/OptionalBooleanParameter from rubocop_todos. (@haroon26) #349
+* Fix Naming/VariableNumber from rubocop_todos. (@haroon26) #351
 
 **Bug Fixes**
 

--- a/lib/rgeo/geographic/interface.rb
+++ b/lib/rgeo/geographic/interface.rb
@@ -106,7 +106,7 @@ module RGeo
           "Spherical",
           has_z_coordinate: opts[:has_z_coordinate],
           has_m_coordinate: opts[:has_m_coordinate],
-          coord_sys: coord_sys || coord_sys_4055,
+          coord_sys: coord_sys || coord_sys4055,
           buffer_resolution: opts[:buffer_resolution],
           wkt_parser: opts[:wkt_parser],
           wkb_parser: opts[:wkb_parser],
@@ -189,7 +189,7 @@ module RGeo
       def simple_mercator_factory(opts = {})
         factory = Geographic::Factory.new(
           "Projected",
-          coord_sys: coord_sys_4326,
+          coord_sys: coord_sys4326,
           srid: 4326,
           wkt_parser: opts[:wkt_parser],
           wkb_parser: opts[:wkb_parser],
@@ -379,16 +379,16 @@ module RGeo
 
       private
 
-      def coord_sys_4055
-        return @coord_sys_4055 if defined?(@coord_sys_4055)
+      def coord_sys4055
+        return @coord_sys4055 if defined?(@coord_sys4055)
 
-        @coord_sys_4055 = CoordSys::CONFIG.default_coord_sys_class.create(4055)
+        @coord_sys4055 = CoordSys::CONFIG.default_coord_sys_class.create(4055)
       end
 
-      def coord_sys_4326
-        return @coord_sys_4326 if defined?(@coord_sys_4326)
+      def coord_sys4326
+        return @coord_sys4326 if defined?(@coord_sys4326)
 
-        @coord_sys_4326 = CoordSys::CONFIG.default_coord_sys_class.create(4326)
+        @coord_sys4326 = CoordSys::CONFIG.default_coord_sys_class.create(4326)
       end
     end
   end

--- a/lib/rgeo/geographic/simple_mercator_projector.rb
+++ b/lib/rgeo/geographic/simple_mercator_projector.rb
@@ -14,7 +14,7 @@ module RGeo
       def initialize(geography_factory, opts = {})
         @geography_factory = geography_factory
         @projection_factory = Cartesian.preferred_factory(srid: 3857,
-                                                          coord_sys: SimpleMercatorProjector._coordsys_3857,
+                                                          coord_sys: SimpleMercatorProjector._coordsys3857,
                                                           buffer_resolution: opts[:buffer_resolution],
                                                           has_z_coordinate: opts[:has_z_coordinate],
                                                           has_m_coordinate: opts[:has_m_coordinate])
@@ -104,10 +104,10 @@ module RGeo
         )
       end
 
-      def self._coordsys_3857 # :nodoc:
-        return @coordsys_3857 if defined?(@coordsys_3857)
+      def self._coordsys3857 # :nodoc:
+        return @coordsys3857 if defined?(@coordsys3857)
 
-        @coordsys_3857 = CoordSys::CONFIG.default_coord_sys_class.create(3857)
+        @coordsys3857 = CoordSys::CONFIG.default_coord_sys_class.create(3857)
       end
     end
   end

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -168,43 +168,43 @@ module RGeo
 
       def disjoint?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep = request_prepared if Utils.ffi_supports_prepared_level2
         prep ? prep.disjoint?(fg) : @fg_geom.disjoint?(fg)
       end
 
       def intersects?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        prep = request_prepared if Utils.ffi_supports_prepared_level_1
+        prep = request_prepared if Utils.ffi_supports_prepared_level1
         prep ? prep.intersects?(fg) : @fg_geom.intersects?(fg)
       end
 
       def touches?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep = request_prepared if Utils.ffi_supports_prepared_level2
         prep ? prep.touches?(fg) : @fg_geom.touches?(fg)
       end
 
       def crosses?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep = request_prepared if Utils.ffi_supports_prepared_level2
         prep ? prep.crosses?(fg) : @fg_geom.crosses?(fg)
       end
 
       def within?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep = request_prepared if Utils.ffi_supports_prepared_level2
         prep ? prep.within?(fg) : @fg_geom.within?(fg)
       end
 
       def contains?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        prep = request_prepared if Utils.ffi_supports_prepared_level_1
+        prep = request_prepared if Utils.ffi_supports_prepared_level1
         prep ? prep.contains?(fg) : @fg_geom.contains?(fg)
       end
 
       def overlaps?(rhs)
         fg = factory.convert_to_fg_geometry(rhs)
-        prep = request_prepared if Utils.ffi_supports_prepared_level_2
+        prep = request_prepared if Utils.ffi_supports_prepared_level2
         prep ? prep.overlaps?(fg) : @fg_geom.overlaps?(fg)
       end
 

--- a/lib/rgeo/geos/utils.rb
+++ b/lib/rgeo/geos/utils.rb
@@ -55,11 +55,11 @@ module RGeo
           end
         end
 
-        def ffi_supports_prepared_level_1
+        def ffi_supports_prepared_level1
           FFI_SUPPORTED && ::Geos::FFIGeos.respond_to?(:GEOSPreparedContains_r)
         end
 
-        def ffi_supports_prepared_level_2
+        def ffi_supports_prepared_level2
           FFI_SUPPORTED && ::Geos::FFIGeos.respond_to?(:GEOSPreparedDisjoint_r)
         end
 

--- a/test/coord_sys/ogc_cs_test.rb
+++ b/test/coord_sys/ogc_cs_test.rb
@@ -506,7 +506,7 @@ class OgcCsTest < Minitest::Test # :nodoc:
     assert_equal(ct.target_cs, inv_ct.source_cs)
   end
 
-  def test_parse_epsg_6055
+  def test_parse_epsg6055
     input = 'DATUM["Popular_Visualisation_Datum",SPHEROID["Popular Visualisation Sphere",6378137.0,0.0,' \
             'AUTHORITY["EPSG","7059"]],TOWGS84[0.0,0.0,0.0,0.0,0.0,0.0,0.0],AUTHORITY["EPSG","6055"]]'
     obj = RGeo::CoordSys::CS.create_from_wkt(input)
@@ -525,7 +525,7 @@ class OgcCsTest < Minitest::Test # :nodoc:
     assert_equal(input, obj.to_wkt)
   end
 
-  def test_parse_epsg_7405
+  def test_parse_epsg7405
     input = 'COMPD_CS["OSGB36 / British National Grid + ODN",PROJCS["OSGB 1936 / British National Grid",GEOGCS[' \
             '"OSGB 1936",DATUM["OSGB 1936",SPHEROID["Airy 1830",6377563.396,299.3249646,AUTHORITY["EPSG","7001"]],' \
             'TOWGS84[446.448,-125.157,542.06,0.15,0.247,0.842,-4.2261596151967575],AUTHORITY["EPSG","6277"]],' \

--- a/test/geos_capi/misc_test.rb
+++ b/test/geos_capi/misc_test.rb
@@ -89,7 +89,7 @@ class GeosMiscTest < Minitest::Test # :nodoc:
     assert_equal(false, polygon2.prepared?)
   end
 
-  def test_gh_21
+  def test_gh21
     # Test for GH-21 (seg fault in rgeo_convert_to_geos_geometry)
     # This seemed to fail under Ruby 1.8.7 only.
     f = RGeo::Geographic.simple_mercator_factory

--- a/test/geos_capi/multi_polygon_test.rb
+++ b/test/geos_capi/multi_polygon_test.rb
@@ -23,7 +23,7 @@ class GeosMultiPolygonTest < Minitest::Test # :nodoc:
     assert_equal(@factory.collection([]), @factory.multi_polygon([]).centroid)
   end
 
-  def test_geos_bug_582
+  def test_geos_bug582
     f = RGeo::Geos.factory(buffer_resolution: 2)
     p1 = f.polygon(f.linear_ring([]))
     p2 = f.polygon(f.linear_ring([f.point(0, 0), f.point(0, 1), f.point(1, 1), f.point(1, 0)]))

--- a/test/simple_cartesian/point_test.rb
+++ b/test/simple_cartesian/point_test.rb
@@ -29,7 +29,7 @@ class CartesianPointTest < Minitest::Test # :nodoc:
     assert_in_delta(13, point1.distance(point2), 0.0001)
   end
 
-  def test_lon_180
+  def test_lon180
     factory = RGeo::Geographic.simple_mercator_factory
     points = [
       [48.02006, -179.47466],


### PR DESCRIPTION
### Summary

Fix `Naming/VariableNumber` offense
Updates Issue #336