### PR TITLE
Remove Lint/MissingSuper rubocop offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 4
-Lint/MissingSuper:
-  Exclude:
-    - 'lib/rgeo/coord_sys/cs/entities.rb'
-
 # Offense count: 3
 Lint/NonLocalExitFromIterator:
   Exclude:

--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@
 * Add `transform` method to `Geometry`. #342
 * Fix rubocop_todos and other refactoring. (@thestelz) #338
 * Fix Style/OptionalBooleanParameter from rubocop_todos. (@haroon26) #349
+* Fix Lint/MissingSuper from rubocop_todos. (@haroon26) #352
 
 **Bug Fixes**
 

--- a/lib/rgeo/coord_sys/cs/entities.rb
+++ b/lib/rgeo/coord_sys/cs/entities.rb
@@ -251,6 +251,7 @@ module RGeo
         # :startdoc:
 
         def initialize(name, orientation) # :nodoc:
+          super()
           @name = name
           @orientation =
             case orientation
@@ -302,6 +303,7 @@ module RGeo
       # system that the projected coordinate system is based on.
       class ProjectionParameter < Base
         def initialize(name, value) # :nodoc:
+          super()
           @name = name
           @value = value.to_f
         end
@@ -339,6 +341,7 @@ module RGeo
       # points East, and the Z axis points North.
       class WGS84ConversionInfo < Base
         def initialize(dx_meters, dy_meters, dz_meters, ex_arc_seconds, ey_arc_seconds, ez_arc_seconds, ppm) # :nodoc:
+          super()
           @dx = dx_meters.to_f
           @dy = dy_meters.to_f
           @dz = dz_meters.to_f
@@ -427,6 +430,7 @@ module RGeo
       class Info < Base
         def initialize(name, authority = nil, authority_code = nil, abbreviation = nil, init_alias = nil,
                        remarks = nil, extensions = nil) # :nodoc:
+          super()
           @name = name
           @authority = authority ? authority.to_s : nil
           @authority_code = authority_code ? authority_code.to_s : nil


### PR DESCRIPTION
### Summary

Fix `LInt/MissingSuper` rubocop offense.
Updates Issue #336