### PR TITLE
drop support for ruby 2.6 and test jruby

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,11 +13,11 @@ jobs:
       matrix:
         ruby:
           - head
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'
-          - '2.6'
-          - "jruby-9.3.7.0"
+          - "jruby"
         os:
           - ubuntu
           # Windows users, feel free to open a PR :)
@@ -29,7 +29,7 @@ jobs:
     continue-on-error: ${{ matrix.ruby == 'head' || matrix.os == 'windows' || matrix.os == 'macos' }}
     name: Ruby ${{ matrix.ruby }} (${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -55,7 +55,7 @@ jobs:
   Memcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
@@ -69,7 +69,7 @@ jobs:
   RuboCop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 'head'
@@ -82,7 +82,7 @@ jobs:
     #   outdated clang-format package.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install clang-format
         run: sudo apt-get install -yqq clang-format
       - name: Show version

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ mkmf.log
 Gemfile.lock
 /yardoc
 /.yardoc
+.tool-versions

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  # Version support must stay 2.6 for JRuby. We do not advise using it
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   NewCops: enable
 
 Layout/ParameterAlignment:

--- a/rgeo.gemspec
+++ b/rgeo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Daniel Azuma", "Tee Parham"]
   spec.email = ["dazuma@gmail.com", "parhameter@gmail.com", "kfdoggett@gmail.com", "buonomo.ulysse@gmail.com"]
   spec.homepage = "https://github.com/rgeo/rgeo"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.7"
   spec.license = "BSD-3-Clause"
 
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
### Summary

We are currently testing support for Ruby 2.6 to ensure compatibility with JRuby. However, JRuby now supports versions 2.7 to 3.1. I think upgrading the support to at least Ruby 2.7, which is nearing its end-of-life. Or even go directly to 3.0.

@keithdoggett , I want to give some maintenance shot to the repos. 
Can you enable ci for my pr ?

