### PR TITLE
Update Github pages links to use github.io and use HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,13 +60,13 @@
 </ul><p>For more information:</p>
 
 <ul>
-<li>See the <a href="http://rgeo.github.com/rgeo/rdoc">documentation</a>
+<li>See the <a href="https://rgeo.github.io/rgeo/rdoc">documentation</a>
 </li>
-<li>Source code on <a href="http://github.com/rgeo/rgeo">Github</a>
+<li>Source code on <a href="https://github.com/rgeo/rgeo">Github</a>
 </li>
-<li>Report issues <a href="http://github.com/rgeo/rgeo/issues">here</a>
+<li>Report issues <a href="https://github.com/rgeo/rgeo/issues">here</a>
 </li>
-<li>Questions? Ask on the <a href="http://groups.google.com/group/rgeo-users">mailing list</a>
+<li>Questions? Ask on the <a href="https://groups.google.com/group/rgeo-users">mailing list</a>
 </li>
 </ul>
       </section>


### PR DESCRIPTION
### Summary

Github Pages has deprecated using github.com for pages since April 2021, and github.io should be used instead. This commit also updates protocols used in link URLs to use HTTPS rather than HTTP. I'm not sure how many people aim to find out more about RGeo via the github pages site, but since it showed up via search for me I thought it was worth fixing up the link to the docs.
