### PR TITLE
remove deprecated aliases

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
   RuboCop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 'head'
@@ -88,7 +88,7 @@ jobs:
     #   outdated clang-format package.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install clang-format
         run: sudo apt-get install -yqq clang-format
       - name: Show version

--- a/lib/rgeo/geos/ffi_feature_methods.rb
+++ b/lib/rgeo/geos/ffi_feature_methods.rb
@@ -212,7 +212,6 @@ module RGeo
         fg = factory.convert_to_fg_geometry(rhs)
         @fg_geom.relate_pattern(fg, pattern)
       end
-      alias relate relate? # DEPRECATED
 
       def distance(rhs)
         fg = factory.convert_to_fg_geometry(rhs)

--- a/lib/rgeo/geos/zm_feature_methods.rb
+++ b/lib/rgeo/geos/zm_feature_methods.rb
@@ -128,7 +128,6 @@ module RGeo
       def relate?(rhs, pattern)
         @zgeometry.relate?(RGeo::Feature.cast(rhs, self).z_geometry, pattern)
       end
-      alias relate relate? # DEPRECATED
 
       def distance(rhs)
         @zgeometry.distance(RGeo::Feature.cast(rhs, self).z_geometry)


### PR DESCRIPTION
### Summary

remove deprecated aliases. 
Those aliases were deprecated in 2018.