### PR TITLE
feat: Segmentize for GeosCapi geometries.

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
 * Fix Naming/VariableNumber from rubocop_todos. (@haroon26) #351
 * Fix Lint/MissingSuper from rubocop_todos. (@haroon26) #352
 * Drop support for Ruby 2.6. (@seuros) #353
+* Add `segmentize` method to CAPI geometires (@arkirchner) #364
 
 **Bug Fixes**
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ RGeo works with the following Ruby implementations:
 
 Some features also require the following:
 
-*   GEOS 3.2 or later is highly recommended. (3.3.3 or later preferred.) Some
-    functions will not be available without it. This C/C++ library may be
+*   GEOS 3.10 or later is highly recommended. Some functions will not be available without it. This C/C++ library may be
     available via your operating system's package manager (`sudo aptitude
     install libgeos-dev` for debian based Linux distributions, `yum install geos geos-devel` for redhat based Linux distributions), or you can
     download it from http://trac.osgeo.org/geos

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ RGeo works with the following Ruby implementations:
 
 Some features also require the following:
 
-*   GEOS 3.10 or later is highly recommended. Some functions will not be available without it. This C/C++ library may be
+*   GEOS 3.2 or later is highly recommended. (3.3.3 or later preferred.) Some
+    functions will not be available without it. This C/C++ library may be
     available via your operating system's package manager (`sudo aptitude
     install libgeos-dev` for debian based Linux distributions, `yum install geos geos-devel` for redhat based Linux distributions), or you can
     download it from http://trac.osgeo.org/geos

--- a/ext/geos_c_impl/extconf.rb
+++ b/ext/geos_c_impl/extconf.rb
@@ -45,6 +45,7 @@ if have_header("geos_c.h")
   have_func("GEOSPreparedDisjoint_r", "geos_c.h")
   have_func("GEOSUnaryUnion_r", "geos_c.h")
   have_func("GEOSCoordSeq_isCCW_r", "geos_c.h")
+  have_func("GEOSDensify", "geos_c.h")
   have_func("rb_memhash", "ruby.h")
   have_func("rb_gc_mark_movable", "ruby.h")
 end

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -741,6 +741,27 @@ method_geometry_buffer(VALUE self, VALUE distance)
 }
 
 static VALUE
+method_geometry_segmentize(VALUE self, VALUE max_segment_length)
+{
+  VALUE result;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  VALUE factory;
+
+  result = Qnil;
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+  if (self_geom) {
+    factory = self_data->factory;
+    result = rgeo_wrap_geos_geometry(
+      factory,
+      GEOSDensify(self_geom, rb_num2dbl(max_segment_length)),
+      Qnil);
+  }
+  return result;
+}
+
+static VALUE
 method_geometry_buffer_with_style(VALUE self,
                                   VALUE distance,
                                   VALUE endCapStyle,
@@ -1308,6 +1329,8 @@ rgeo_init_geos_geometry()
     geos_geometry_methods, "make_valid", method_geometry_make_valid, 0);
   rb_define_method(
     geos_geometry_methods, "polygonize", method_geometry_polygonize, 0);
+  rb_define_method(
+    geos_geometry_methods, "segmentize", method_geometry_segmentize, 1);
 }
 
 RGEO_END_C

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -740,6 +740,7 @@ method_geometry_buffer(VALUE self, VALUE distance)
   return result;
 }
 
+#ifdef RGEO_GEOS_SUPPORTS_DENSIFY
 static VALUE
 method_geometry_segmentize(VALUE self, VALUE max_segment_length)
 {
@@ -758,6 +759,7 @@ method_geometry_segmentize(VALUE self, VALUE max_segment_length)
   }
   return result;
 }
+#endif
 
 static VALUE
 method_geometry_buffer_with_style(VALUE self,
@@ -1327,8 +1329,10 @@ rgeo_init_geos_geometry()
     geos_geometry_methods, "make_valid", method_geometry_make_valid, 0);
   rb_define_method(
     geos_geometry_methods, "polygonize", method_geometry_polygonize, 0);
+#ifdef RGEO_GEOS_SUPPORTS_DENSIFY
   rb_define_method(
     geos_geometry_methods, "segmentize", method_geometry_segmentize, 1);
+#endif
 }
 
 RGEO_END_C

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -754,9 +754,7 @@ method_geometry_segmentize(VALUE self, VALUE max_segment_length)
   if (self_geom) {
     factory = self_data->factory;
     result = rgeo_wrap_geos_geometry(
-      factory,
-      GEOSDensify(self_geom, rb_num2dbl(max_segment_length)),
-      Qnil);
+      factory, GEOSDensify(self_geom, rb_num2dbl(max_segment_length)), Qnil);
   }
   return result;
 }

--- a/ext/geos_c_impl/preface.h
+++ b/ext/geos_c_impl/preface.h
@@ -23,6 +23,9 @@
 #ifdef HAVE_GEOSCOORDSEQ_ISCCW_R
 #define RGEO_GEOS_SUPPORTS_ISCCW
 #endif
+#ifdef HAVE_GEOSDENSIFY
+#define RGEO_GEOS_SUPPORTS_DENSIFY
+#endif
 #ifdef HAVE_RB_GC_MARK_MOVABLE
 #define mark rb_gc_mark_movable
 #else

--- a/test/geos_capi/line_string_test.rb
+++ b/test/geos_capi/line_string_test.rb
@@ -52,4 +52,11 @@ class GeosLineStringTest < Minitest::Test # :nodoc:
 
     assert_equal expected, input.polygonize
   end
+
+  def test_polygonize_dangle
+    input = @factory.parse_wkt("LINESTRING(0 0, 0 10)")
+    expected = @factory.parse_wkt("LINESTRING (0 0, 0 5, 0 10)")
+
+    assert_equal expected, input.segmentize(5)
+  end
 end

--- a/test/geos_capi/line_string_test.rb
+++ b/test/geos_capi/line_string_test.rb
@@ -9,7 +9,6 @@
 require_relative "../test_helper"
 require_relative "./skip_capi"
 
-
 class GeosLineStringTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::LineStringTests
   prepend SkipCAPI

--- a/test/geos_capi/line_string_test.rb
+++ b/test/geos_capi/line_string_test.rb
@@ -7,9 +7,12 @@
 # -----------------------------------------------------------------------------
 
 require_relative "../test_helper"
+require_relative "./skip_capi"
+
 
 class GeosLineStringTest < Minitest::Test # :nodoc:
   include RGeo::Tests::Common::LineStringTests
+  prepend SkipCAPI
 
   def setup
     skip "CAPI not supported" unless RGeo::Geos.capi_supported?
@@ -54,6 +57,8 @@ class GeosLineStringTest < Minitest::Test # :nodoc:
   end
 
   def test_segmentize
+    skip_geos_version_less_then("3.10")
+
     input = @factory.parse_wkt("LINESTRING(0 0, 0 10)")
     expected = @factory.parse_wkt("LINESTRING (0 0, 0 5, 0 10)")
 

--- a/test/geos_capi/line_string_test.rb
+++ b/test/geos_capi/line_string_test.rb
@@ -58,5 +58,9 @@ class GeosLineStringTest < Minitest::Test # :nodoc:
     expected = @factory.parse_wkt("LINESTRING (0 0, 0 5, 0 10)")
 
     assert_equal expected, input.segmentize(5)
+
+    assert_raises(TypeError, "no implicit conversion to float from string") { input.segmentize("a") }
+    assert_raises(TypeError, "no implicit conversion to float from nil") { input.segmentize(nil) }
+    assert_raises(RGeo::Error::InvalidGeometry, "Tolerance must be positive") { input.segmentize(0) }
   end
 end

--- a/test/geos_capi/line_string_test.rb
+++ b/test/geos_capi/line_string_test.rb
@@ -53,7 +53,7 @@ class GeosLineStringTest < Minitest::Test # :nodoc:
     assert_equal expected, input.polygonize
   end
 
-  def test_polygonize_dangle
+  def test_segmentize
     input = @factory.parse_wkt("LINESTRING(0 0, 0 10)")
     expected = @factory.parse_wkt("LINESTRING (0 0, 0 5, 0 10)")
 

--- a/test/geos_capi/polygon_test.rb
+++ b/test/geos_capi/polygon_test.rb
@@ -179,4 +179,11 @@ class GeosPolygonTest < Minitest::Test # :nodoc:
 
     assert_equal expected, input.polygonize
   end
+
+  def test_segmentize
+    input = @factory.parse_wkt("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))")
+    expected = @factory.parse_wkt("POLYGON ((0 0, 5 0, 10 0, 10 5, 10 10, 5 10, 0 10, 0 5, 0 0))")
+
+    assert_equal expected, input.segmentize(5)
+  end
 end

--- a/test/geos_capi/polygon_test.rb
+++ b/test/geos_capi/polygon_test.rb
@@ -181,6 +181,8 @@ class GeosPolygonTest < Minitest::Test # :nodoc:
   end
 
   def test_segmentize
+    skip_geos_version_less_then("3.10")
+
     input = @factory.parse_wkt("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))")
     expected = @factory.parse_wkt("POLYGON ((0 0, 5 0, 10 0, 10 5, 10 10, 5 10, 0 10, 0 5, 0 0))")
 

--- a/test/geos_capi/polygon_test.rb
+++ b/test/geos_capi/polygon_test.rb
@@ -185,5 +185,9 @@ class GeosPolygonTest < Minitest::Test # :nodoc:
     expected = @factory.parse_wkt("POLYGON ((0 0, 5 0, 10 0, 10 5, 10 10, 5 10, 0 10, 0 5, 0 0))")
 
     assert_equal expected, input.segmentize(5)
+
+    assert_raises(TypeError, "no implicit conversion to float from string") { input.segmentize("a") }
+    assert_raises(TypeError, "no implicit conversion to float from nil") { input.segmentize(nil) }
+    assert_raises(RGeo::Error::InvalidGeometry, "Tolerance must be positive") { input.segmentize(0) }
   end
 end

--- a/test/geos_capi/skip_capi.rb
+++ b/test/geos_capi/skip_capi.rb
@@ -5,4 +5,10 @@ module SkipCAPI
     skip "Needs GEOS CAPI." unless RGeo::Geos.capi_supported?
     super
   end
+
+  def skip_geos_version_less_then(version)
+    return if Gem::Version.new(RGeo::Geos.version) >= Gem::Version.new(version)
+
+    skip "Needs GEOS version #{version} or later."
+  end
 end


### PR DESCRIPTION
### Summary
Modify geometry to have no segment longer then the max segment distance.

Feature is equal to:
[ST_Segmentize](https://postgis.net/docs/ST_Segmentize.html)
[shapely segmentize](https://shapely.readthedocs.io/en/latest/reference/shapely.GeometryCollection.html#shapely.GeometryCollection.segmentize)

### Other Information
- ffi support is planned: https://github.com/dark-panda/ffi-geos/pull/34/files
- I decided against calling the method like the Geos feature because it is popular as segmentize through PostGIS and shapely.