### PR TITLE
feat: add simplify_polygon_hull method

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+**Minor Changes**
+
+* Add `simplify_polygon_hull` method to the CAPI factory (@oleksii-leonov) [#366](https://github.com/rgeo/rgeo/pull/366)
+
 ### 3.0.1 / 2023-11-15
 
 **Minor Changes**

--- a/ext/geos_c_impl/extconf.rb
+++ b/ext/geos_c_impl/extconf.rb
@@ -46,6 +46,7 @@ if have_header("geos_c.h")
   have_func("GEOSUnaryUnion_r", "geos_c.h")
   have_func("GEOSCoordSeq_isCCW_r", "geos_c.h")
   have_func("GEOSDensify", "geos_c.h")
+  have_func("GEOSPolygonHullSimplify", "geos_c.h")
   have_func("rb_memhash", "ruby.h")
   have_func("rb_gc_mark_movable", "ruby.h")
 end

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -831,34 +831,6 @@ method_geometry_simplify_preserve_topology(VALUE self, VALUE tolerance)
   return result;
 }
 
-#ifdef RGEO_GEOS_SUPPORTS_POLYGON_HULL_SIMPLIFY
-static VALUE
-method_geometry_simplify_polygon_hull(VALUE self,
-                                      VALUE vertex_fraction,
-                                      VALUE is_outer)
-{
-  VALUE result;
-  RGeo_GeometryData* self_data;
-  const GEOSGeometry* self_geom;
-  VALUE factory;
-
-  unsigned int is_outer_uint = RTEST(is_outer) ? 1 : 0;
-
-  result = Qnil;
-  self_data = RGEO_GEOMETRY_DATA_PTR(self);
-  self_geom = self_data->geom;
-  if (self_geom) {
-    factory = self_data->factory;
-    result = rgeo_wrap_geos_geometry(
-      factory,
-      GEOSPolygonHullSimplify(
-        self_geom, is_outer_uint, rb_num2dbl(vertex_fraction)),
-      Qnil);
-  }
-  return result;
-}
-#endif
-
 static VALUE
 method_geometry_convex_hull(VALUE self)
 {
@@ -1357,14 +1329,6 @@ rgeo_init_geos_geometry()
     geos_geometry_methods, "make_valid", method_geometry_make_valid, 0);
   rb_define_method(
     geos_geometry_methods, "polygonize", method_geometry_polygonize, 0);
-
-#ifdef RGEO_GEOS_SUPPORTS_POLYGON_HULL_SIMPLIFY
-  rb_define_method(geos_geometry_methods,
-                   "simplify_polygon_hull",
-                   method_geometry_simplify_polygon_hull,
-                   2);
-#endif
-
 #ifdef RGEO_GEOS_SUPPORTS_DENSIFY
   rb_define_method(
     geos_geometry_methods, "segmentize", method_geometry_segmentize, 1);

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -832,6 +832,32 @@ method_geometry_simplify_preserve_topology(VALUE self, VALUE tolerance)
 }
 
 static VALUE
+method_geometry_simplify_polygon_hull(VALUE self,
+                                      VALUE vertex_fraction,
+                                      VALUE is_outer)
+{
+  VALUE result;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  VALUE factory;
+
+  unsigned int is_outer_uint = RTEST(is_outer) ? 1 : 0;
+
+  result = Qnil;
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+  if (self_geom) {
+    factory = self_data->factory;
+    result = rgeo_wrap_geos_geometry(
+      factory,
+      GEOSPolygonHullSimplify(
+        self_geom, is_outer_uint, rb_num2dbl(vertex_fraction)),
+      Qnil);
+  }
+  return result;
+}
+
+static VALUE
 method_geometry_convex_hull(VALUE self)
 {
   VALUE result;
@@ -1329,6 +1355,14 @@ rgeo_init_geos_geometry()
     geos_geometry_methods, "make_valid", method_geometry_make_valid, 0);
   rb_define_method(
     geos_geometry_methods, "polygonize", method_geometry_polygonize, 0);
+
+#ifdef RGEO_GEOS_SUPPORTS_POLYGON_HULL_SIMPLIFY
+  rb_define_method(geos_geometry_methods,
+                   "simplify_polygon_hull",
+                   method_geometry_simplify_polygon_hull,
+                   2);
+#endif
+
 #ifdef RGEO_GEOS_SUPPORTS_DENSIFY
   rb_define_method(
     geos_geometry_methods, "segmentize", method_geometry_segmentize, 1);

--- a/ext/geos_c_impl/geometry.c
+++ b/ext/geos_c_impl/geometry.c
@@ -831,6 +831,7 @@ method_geometry_simplify_preserve_topology(VALUE self, VALUE tolerance)
   return result;
 }
 
+#ifdef RGEO_GEOS_SUPPORTS_POLYGON_HULL_SIMPLIFY
 static VALUE
 method_geometry_simplify_polygon_hull(VALUE self,
                                       VALUE vertex_fraction,
@@ -856,6 +857,7 @@ method_geometry_simplify_polygon_hull(VALUE self,
   }
   return result;
 }
+#endif
 
 static VALUE
 method_geometry_convex_hull(VALUE self)

--- a/ext/geos_c_impl/polygon.c
+++ b/ext/geos_c_impl/polygon.c
@@ -231,6 +231,34 @@ method_polygon_interior_rings(VALUE self)
   return result;
 }
 
+#ifdef RGEO_GEOS_SUPPORTS_POLYGON_HULL_SIMPLIFY
+static VALUE
+method_polygon_simplify_polygon_hull(VALUE self,
+                                     VALUE vertex_fraction,
+                                     VALUE is_outer)
+{
+  VALUE result;
+  RGeo_GeometryData* self_data;
+  const GEOSGeometry* self_geom;
+  VALUE factory;
+
+  unsigned int is_outer_uint = RTEST(is_outer) ? 1 : 0;
+
+  result = Qnil;
+  self_data = RGEO_GEOMETRY_DATA_PTR(self);
+  self_geom = self_data->geom;
+  if (self_geom) {
+    factory = self_data->factory;
+    result = rgeo_wrap_geos_geometry(
+      factory,
+      GEOSPolygonHullSimplify(
+        self_geom, is_outer_uint, rb_num2dbl(vertex_fraction)),
+      Qnil);
+  }
+  return result;
+}
+#endif
+
 static VALUE
 cmethod_create(VALUE module,
                VALUE factory,
@@ -335,6 +363,13 @@ rgeo_init_geos_polygon()
     geos_polygon_methods, "interior_rings", method_polygon_interior_rings, 0);
   rb_define_method(
     geos_polygon_methods, "coordinates", method_polygon_coordinates, 0);
+
+#ifdef RGEO_GEOS_SUPPORTS_POLYGON_HULL_SIMPLIFY
+  rb_define_method(geos_polygon_methods,
+                   "simplify_polygon_hull",
+                   method_polygon_simplify_polygon_hull,
+                   2);
+#endif
 }
 
 st_index_t

--- a/ext/geos_c_impl/preface.h
+++ b/ext/geos_c_impl/preface.h
@@ -26,6 +26,9 @@
 #ifdef HAVE_GEOSDENSIFY
 #define RGEO_GEOS_SUPPORTS_DENSIFY
 #endif
+#ifdef HAVE_GEOSPOLYGONHULLSIMPLIFY
+#define RGEO_GEOS_SUPPORTS_POLYGON_HULL_SIMPLIFY
+#endif
 #ifdef HAVE_RB_GC_MARK_MOVABLE
 #define mark rb_gc_mark_movable
 #else


### PR DESCRIPTION
### Summary

The feature is equal to [ST_SimplifyPolygonHull](https://postgis.net/docs/ST_SimplifyPolygonHull.html) in PostGIS.

> Computes a simplified topology-preserving outer or inner hull of a polygonal geometry.
> An outer hull completely covers the input geometry.
> An inner hull is completely covered by the input geometry.
> The result is a polygonal geometry formed by a subset of the input vertices.
> MultiPolygons and holes are handled and produce a result with the same structure as the input.
> https://postgis.net/docs/ST_SimplifyPolygonHull.html

Utilizes the `GEOSPolygonHullSimplify` method introduced in [GEOS 3.11.0](https://github.com/libgeos/geos/releases/tag/3.11.0).

### Other Information

- https://github.com/libgeos/geos/issues/603
- https://github.com/libgeos/geos/pull/622
- https://github.com/locationtech/jts/pull/861
- https://github.com/libgeos/geos/commit/1b3521ccfb4de7fb4bd15ebfa4772b2da8155f30
