### PR TITLE
fix: use expand_heap for Ruby 3.2.0+

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,7 +40,11 @@ require_relative "support/minitest/fixtures"
 # Static test for missed references in our CAPI codebase (or FFI interface).
 # See https://alanwu.space/post/check-compaction/
 if defined?(GC.verify_compaction_references) == "method"
-  GC.verify_compaction_references(double_heap: true, toward: :empty)
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2.0")
+    GC.verify_compaction_references(expand_heap: true, toward: :empty)
+  else
+    GC.verify_compaction_references(double_heap: true, toward: :empty)
+  end
 end
 
 # Live test for our implementation of Ruby's compaction methods (rb_gc_mark_movable


### PR DESCRIPTION
### Summary

Starting Ruby 3.2.0 `GC.verify_compaction_references(expand_heap: true, toward: :empty)` should be used instead of `GC.verify_compaction_references(double_heap: true, toward: :empty)`.

Before:

```shell
ruby -Ilib:test test/geos_capi/polygon_test.rb
<internal:gc>:251: warning: double_heap is deprecated, please use expand_heap instead
  # ...
```

After:

```shell
ruby -Ilib:test test/geos_capi/polygon_test.rb
  # ...
```