### PR TITLE
Use require as a fallback to load geos_c_impl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@
 
 source "https://rubygems.org"
 
+gem "base64"
+
 gemspec

--- a/lib/rgeo/geos.rb
+++ b/lib/rgeo/geos.rb
@@ -26,7 +26,7 @@ module RGeo
     begin
       require_relative "geos/geos_c_impl"
     rescue LoadError
-      # continue
+      require "geos/geos_c_impl"
     end
     CAPI_SUPPORTED = RGeo::Geos.const_defined?(:CAPIGeometryMethods)
     if CAPI_SUPPORTED

--- a/lib/rgeo/geos.rb
+++ b/lib/rgeo/geos.rb
@@ -26,6 +26,8 @@ module RGeo
     begin
       require_relative "geos/geos_c_impl"
     rescue LoadError
+      # fall back to a system-wide search if the c-extension is stored in different location
+      # important for systems such as Amazon Linux
       begin
         require "geos/geos_c_impl"
       rescue LoadError

--- a/lib/rgeo/geos.rb
+++ b/lib/rgeo/geos.rb
@@ -26,7 +26,11 @@ module RGeo
     begin
       require_relative "geos/geos_c_impl"
     rescue LoadError
-      require "geos/geos_c_impl"
+      begin
+        require "geos/geos_c_impl"
+      rescue LoadError
+        # continue
+      end
     end
     CAPI_SUPPORTED = RGeo::Geos.const_defined?(:CAPIGeometryMethods)
     if CAPI_SUPPORTED


### PR DESCRIPTION
Resolves: https://github.com/rgeo/rgeo/issues/365

Important for systems such as Amazon Linux where c-extensions are stored in a different location than Ruby files

`/usr/local/share/ruby3.2-gems/gems/rgeo-3.0.0/ext/geos_c_impl`
vs
`/usr/share/ruby3.2-gems/gems/rgeo-3.0.1/lib/rgeo/geos.rb`

