### PR TITLE
Adds distance method from spherical LineString to Point

### DIFF
--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -152,6 +152,8 @@ module RGeo
 
         # returns PointXYZ
         def closest_point(obj)
+          return s if e == s
+
           projection = project_point(obj)
 
           # Check if the projected point is within the bounds of the arc

--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -161,7 +161,7 @@ module RGeo
           projection = project_point(obj)
 
           # Check if the projected point is within the bounds of the arc
-          if contains_point?(projection)
+          if contains_point?(projection, PLANE_EPSILON)
             projection
           else
             # If not within the arc, return the closer endpoint of the arc
@@ -172,6 +172,8 @@ module RGeo
         # returns PointXYZ
         def project_point(obj)
           # Project the point onto the plane of the great circle defined by the arc
+          # Floating-point error can leave the projected point about 1e-16 off the
+          # plane, so callers that test plane membership may need a small tolerance.
           point_to_plane_distance = obj * axis
           projection = PointXYZ.new(
             obj.x - point_to_plane_distance * axis.x,
@@ -189,12 +191,12 @@ module RGeo
           @axis
         end
 
-        def contains_point?(obj)
+        def contains_point?(obj, tolerance = 0)
           my_axis = axis
           s_axis = ArcXYZ.new(@s, obj).axis
           e_axis = ArcXYZ.new(obj, @e).axis
           !s_axis || !e_axis ||
-            (obj * my_axis).abs <= PLANE_EPSILON &&
+            (obj * my_axis).abs <= tolerance &&
             s_axis * my_axis > 0 &&
             e_axis * my_axis > 0
         end

--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -124,6 +124,10 @@ module RGeo
       # Represents a finite arc on the sphere.
 
       class ArcXYZ # :nodoc:
+        # Projections onto the great-circle plane can leave residuals around 1e-16,
+        # so containment checks need tolerance instead of exact plane equality.
+        PLANE_EPSILON = 1E-12
+
         attr_reader :s, :e
 
         def initialize(start, stop)
@@ -189,7 +193,10 @@ module RGeo
           my_axis = axis
           s_axis = ArcXYZ.new(@s, obj).axis
           e_axis = ArcXYZ.new(obj, @e).axis
-          !s_axis || !e_axis || obj * my_axis == 0 && s_axis * my_axis > 0 && e_axis * my_axis > 0
+          !s_axis || !e_axis ||
+            (obj * my_axis).abs <= PLANE_EPSILON &&
+            s_axis * my_axis > -PLANE_EPSILON &&
+            e_axis * my_axis > -PLANE_EPSILON
         end
 
         def intersects_arc?(obj)

--- a/lib/rgeo/geographic/spherical_math.rb
+++ b/lib/rgeo/geographic/spherical_math.rb
@@ -195,8 +195,8 @@ module RGeo
           e_axis = ArcXYZ.new(obj, @e).axis
           !s_axis || !e_axis ||
             (obj * my_axis).abs <= PLANE_EPSILON &&
-            s_axis * my_axis > -PLANE_EPSILON &&
-            e_axis * my_axis > -PLANE_EPSILON
+            s_axis * my_axis > 0 &&
+            e_axis * my_axis > 0
         end
 
         def intersects_arc?(obj)

--- a/test/spherical_geographic/calculations_test.rb
+++ b/test/spherical_geographic/calculations_test.rb
@@ -243,5 +243,4 @@ class SphericalCalculationsTest < Minitest::Test # :nodoc:
     # Since the projected point is outside the arc, it shoudl return the closer end of the arc
     assert_equal(closest_point, point1)
   end
-
 end

--- a/test/spherical_geographic/calculations_test.rb
+++ b/test/spherical_geographic/calculations_test.rb
@@ -245,16 +245,16 @@ class SphericalCalculationsTest < Minitest::Test # :nodoc:
   end
 
   def test_arc_contains_projected_point_with_floating_point_error
-    seattle = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(47.5, -122.2)
-    brussels = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(50.8, 4.35)
-    reykjavik = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(64.13, -21.83)
+    seattle = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(47.449, -122.309)
+    bern = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(46.9125, 7.4992)
+    reykjavik = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(64.13, -21.9406)
 
-    arc = RGeo::Geographic::SphericalMath::ArcXYZ.new(seattle, brussels)
+    arc = RGeo::Geographic::SphericalMath::ArcXYZ.new(seattle, bern)
     projected_point = arc.project_point(reykjavik)
 
     refute(arc.contains_point?(projected_point))
     assert(arc.contains_point?(projected_point, RGeo::Geographic::SphericalMath::ArcXYZ::PLANE_EPSILON))
-    assert_in_delta(38_786.28, projected_point.dist_to_point(reykjavik) * RGeo::Geographic::SphericalMath::RADIUS,
-                    100.0)
+    distance = projected_point.dist_to_point(reykjavik) * RGeo::Geographic::SphericalMath::RADIUS
+    assert_in_delta(3874, distance, 10.0)
   end
 end

--- a/test/spherical_geographic/calculations_test.rb
+++ b/test/spherical_geographic/calculations_test.rb
@@ -252,7 +252,8 @@ class SphericalCalculationsTest < Minitest::Test # :nodoc:
     arc = RGeo::Geographic::SphericalMath::ArcXYZ.new(seattle, brussels)
     projected_point = arc.project_point(reykjavik)
 
-    assert(arc.contains_point?(projected_point))
+    refute(arc.contains_point?(projected_point))
+    assert(arc.contains_point?(projected_point, RGeo::Geographic::SphericalMath::ArcXYZ::PLANE_EPSILON))
     assert_in_delta(38_786.28, projected_point.dist_to_point(reykjavik) * RGeo::Geographic::SphericalMath::RADIUS,
                     100.0)
   end

--- a/test/spherical_geographic/calculations_test.rb
+++ b/test/spherical_geographic/calculations_test.rb
@@ -243,4 +243,17 @@ class SphericalCalculationsTest < Minitest::Test # :nodoc:
     # Since the projected point is outside the arc, it shoudl return the closer end of the arc
     assert_equal(closest_point, point1)
   end
+
+  def test_arc_contains_projected_point_with_floating_point_error
+    seattle = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(47.5, -122.2)
+    brussels = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(50.8, 4.35)
+    reykjavik = RGeo::Geographic::SphericalMath::PointXYZ.from_latlon(64.13, -21.83)
+
+    arc = RGeo::Geographic::SphericalMath::ArcXYZ.new(seattle, brussels)
+    projected_point = arc.project_point(reykjavik)
+
+    assert(arc.contains_point?(projected_point))
+    assert_in_delta(38_786.28, projected_point.dist_to_point(reykjavik) * RGeo::Geographic::SphericalMath::RADIUS,
+                    100.0)
+  end
 end

--- a/test/spherical_geographic/line_string_test.rb
+++ b/test/spherical_geographic/line_string_test.rb
@@ -11,9 +11,62 @@ require "test_helper"
 class SphericalLineStringTest < Minitest::Test # :nodoc:
   def setup
     @factory = RGeo::Geographic.spherical_factory
+    @equator_line_string = @factory.line_string([
+      @factory.point(-10.0, 0.0),
+      @factory.point(10.0, 0.0),
+      @factory.point(30.0, 0.0),
+      @factory.point(50.0, 0.0)
+    ])
+    @null_meridian_line_string = @factory.line_string([
+      @factory.point(0.0, -10.0),
+      @factory.point(0.0, 10.0),
+      @factory.point(0.0, 30.0),
+      @factory.point(0.0, 80.0)
+    ])
   end
 
   include RGeo::Tests::Common::LineStringTests
+
+  def test_point_distance
+    point1 = @factory.point(-5.0, 1.0)
+    point2 = @factory.point(20.0, 2.0)
+    point1_distance_rad = @equator_line_string.distance(point1) / (2 * Math::PI * RGeo::Geographic::SphericalMath::RADIUS)
+    point2_distance_rad = @equator_line_string.distance(point2) / (2 * Math::PI * RGeo::Geographic::SphericalMath::RADIUS)
+    assert_in_delta(1.0/360.0, point1_distance_rad, 1E-8)
+    assert_in_delta(2.0/360.0, point2_distance_rad, 1E-8)
+  end
+
+  def test_closest_point_on_equator
+    point = @factory.point(15.0, 1.0)
+    closest_point = @equator_line_string.closest_point(point)
+    assert_in_delta(closest_point.lat, 0, 1E-8)
+    assert_in_delta(closest_point.lon, 15, 1E-8)
+  end
+
+  def test_closest_is_endpoint
+    point = @factory.point(-15.0, -5.0)
+    closest_point = @equator_line_string.closest_point(point)
+    assert_in_delta(closest_point.lat, 0, 1E-8)
+    assert_in_delta(closest_point.lon, -10, 1E-8)
+  end
+
+  def test_closest_point_on_meridian
+    point = @factory.point(1.0, 5.0)
+    closest_point = @null_meridian_line_string.closest_point(point)
+
+    # The further north you get, the the more the closest point is not on the same latitude
+    assert_in_delta(closest_point.lat, 5, 1E-3)
+    assert_in_delta(closest_point.lon, 0, 1E-8)
+  end
+
+  def test_closest_point_on_meridian_north
+    point = @factory.point(10.0, 75.0)
+    closest_point = @null_meridian_line_string.closest_point(point)
+
+    # The further north you get, the the more the closest point is not on the same latitude
+    assert_in_delta(closest_point.lat, 75.21783354642534)
+    assert_in_delta(closest_point.lon, 0, 1E-8)
+  end
 
   undef_method :test_fully_equal
   undef_method :test_geometrically_equal_but_different_type

--- a/test/spherical_geographic/line_string_test.rb
+++ b/test/spherical_geographic/line_string_test.rb
@@ -11,18 +11,22 @@ require "test_helper"
 class SphericalLineStringTest < Minitest::Test # :nodoc:
   def setup
     @factory = RGeo::Geographic.spherical_factory
-    @equator_line_string = @factory.line_string([
-      @factory.point(-10.0, 0.0),
-      @factory.point(10.0, 0.0),
-      @factory.point(30.0, 0.0),
-      @factory.point(50.0, 0.0)
-    ])
-    @null_meridian_line_string = @factory.line_string([
-      @factory.point(0.0, -10.0),
-      @factory.point(0.0, 10.0),
-      @factory.point(0.0, 30.0),
-      @factory.point(0.0, 80.0)
-    ])
+    @equator_line_string = @factory.line_string(
+      [
+        @factory.point(-10.0, 0.0),
+        @factory.point(10.0, 0.0),
+        @factory.point(30.0, 0.0),
+        @factory.point(50.0, 0.0)
+      ]
+    )
+    @null_meridian_line_string = @factory.line_string(
+      [
+        @factory.point(0.0, -10.0),
+        @factory.point(0.0, 10.0),
+        @factory.point(0.0, 30.0),
+        @factory.point(0.0, 80.0)
+      ]
+    )
   end
 
   include RGeo::Tests::Common::LineStringTests
@@ -30,10 +34,11 @@ class SphericalLineStringTest < Minitest::Test # :nodoc:
   def test_point_distance
     point1 = @factory.point(-5.0, 1.0)
     point2 = @factory.point(20.0, 2.0)
-    point1_distance_rad = @equator_line_string.distance(point1) / (2 * Math::PI * RGeo::Geographic::SphericalMath::RADIUS)
-    point2_distance_rad = @equator_line_string.distance(point2) / (2 * Math::PI * RGeo::Geographic::SphericalMath::RADIUS)
-    assert_in_delta(1.0/360.0, point1_distance_rad, 1E-8)
-    assert_in_delta(2.0/360.0, point2_distance_rad, 1E-8)
+    earth_circumference_meters = 2 * Math::PI * RGeo::Geographic::SphericalMath::RADIUS
+    point1_distance_rad = @equator_line_string.distance(point1) / earth_circumference_meters
+    point2_distance_rad = @equator_line_string.distance(point2) / earth_circumference_meters
+    assert_in_delta(1.0 / 360.0, point1_distance_rad, 1E-8)
+    assert_in_delta(2.0 / 360.0, point2_distance_rad, 1E-8)
   end
 
   def test_closest_point_on_equator

--- a/test/spherical_geographic/point_test.rb
+++ b/test/spherical_geographic/point_test.rb
@@ -41,12 +41,27 @@ class SphericalPointTest < Minitest::Test # :nodoc:
     assert_equal(4055, point.srid)
   end
 
-  def test_distance
+  def test_point_distance
     point1 = @factory.point(0, 10)
     point2 = @factory.point(0, 10)
     point3 = @factory.point(0, 40)
     assert_in_delta(0, point1.distance(point2), 0.0001)
     assert_in_delta(Math::PI / 6.0 * RGeo::Geographic::SphericalMath::RADIUS, point1.distance(point3), 0.0001)
+  end
+
+  def test_line_string_distance
+    line_string = @factory.line_string([
+      @factory.point(-10.0, 0.0),
+      @factory.point(10.0, 0.0),
+      @factory.point(30.0, 0.0),
+      @factory.point(50.0, 0.0)
+    ])
+    point1 = @factory.point(-5.0, 1.0)
+    point2 = @factory.point(20.0, 2.0)
+    point1_distance_rad = point1.distance(line_string) / (2 * Math::PI * RGeo::Geographic::SphericalMath::RADIUS)
+    point2_distance_rad = point2.distance(line_string) / (2 * Math::PI * RGeo::Geographic::SphericalMath::RADIUS)
+    assert_in_delta(1.0/360.0, point1_distance_rad, 1E-8)
+    assert_in_delta(2.0/360.0, point2_distance_rad, 1E-8)
   end
 
   def test_floating_point_perturbation

--- a/test/spherical_geographic/point_test.rb
+++ b/test/spherical_geographic/point_test.rb
@@ -66,6 +66,18 @@ class SphericalPointTest < Minitest::Test # :nodoc:
     assert_in_delta(2.0 / 360.0, point2_distance_rad, 1E-8)
   end
 
+  def test_line_string_diagonal_arc
+    # https://jsfiddle.net/kLocyn6s/44/
+    seattle = @factory.point(-122.2, 47.5)
+    brussels = @factory.point(4.35, 50.8)
+    reykjavik = @factory.point(-21.83, 64.13)
+
+    seattle_brussels_arc = @factory.line_string([seattle, brussels])
+    distance = reykjavik.distance(seattle_brussels_arc)
+    # This isn't very precise, but it shows, that the arc is broadly near (50km) reykjavik:
+    assert_in_delta(50_000, distance, 50_000)
+  end
+
   def test_floating_point_perturbation
     # A naive way of wrapping longitudes to [-180,180] might cause
     # perturbation due to floating point errors. Make sure this

--- a/test/spherical_geographic/point_test.rb
+++ b/test/spherical_geographic/point_test.rb
@@ -50,18 +50,20 @@ class SphericalPointTest < Minitest::Test # :nodoc:
   end
 
   def test_line_string_distance
-    line_string = @factory.line_string([
-      @factory.point(-10.0, 0.0),
-      @factory.point(10.0, 0.0),
-      @factory.point(30.0, 0.0),
-      @factory.point(50.0, 0.0)
-    ])
+    line_string = @factory.line_string(
+      [
+        @factory.point(-10.0, 0.0),
+        @factory.point(10.0, 0.0),
+        @factory.point(30.0, 0.0),
+        @factory.point(50.0, 0.0)
+      ]
+    )
     point1 = @factory.point(-5.0, 1.0)
     point2 = @factory.point(20.0, 2.0)
     point1_distance_rad = point1.distance(line_string) / (2 * Math::PI * RGeo::Geographic::SphericalMath::RADIUS)
     point2_distance_rad = point2.distance(line_string) / (2 * Math::PI * RGeo::Geographic::SphericalMath::RADIUS)
-    assert_in_delta(1.0/360.0, point1_distance_rad, 1E-8)
-    assert_in_delta(2.0/360.0, point2_distance_rad, 1E-8)
+    assert_in_delta(1.0 / 360.0, point1_distance_rad, 1E-8)
+    assert_in_delta(2.0 / 360.0, point2_distance_rad, 1E-8)
   end
 
   def test_floating_point_perturbation

--- a/test/spherical_geographic/point_test.rb
+++ b/test/spherical_geographic/point_test.rb
@@ -67,7 +67,7 @@ class SphericalPointTest < Minitest::Test # :nodoc:
   end
 
   def test_line_string_diagonal_arc
-    # https://jsfiddle.net/kLocyn6s/44/
+    # https://jsfiddle.net/sz29hr3w/3/
     seattle = @factory.point(-122.2, 47.5)
     brussels = @factory.point(4.35, 50.8)
     reykjavik = @factory.point(-21.83, 64.13)

--- a/test/spherical_geographic/point_test.rb
+++ b/test/spherical_geographic/point_test.rb
@@ -67,15 +67,15 @@ class SphericalPointTest < Minitest::Test # :nodoc:
   end
 
   def test_line_string_diagonal_arc
-    # https://jsfiddle.net/sz29hr3w/3/
-    seattle = @factory.point(-122.2, 47.5)
-    brussels = @factory.point(4.35, 50.8)
-    reykjavik = @factory.point(-21.83, 64.13)
+    # https://jsfiddle.net/sz29hr3w/5/
+    seattle = @factory.point(-122.309, 47.449)
+    bern = @factory.point(7.4992, 46.9125)
+    reykjavik = @factory.point(-21.9406, 64.13)
 
-    seattle_brussels_arc = @factory.line_string([seattle, brussels])
-    distance = reykjavik.distance(seattle_brussels_arc)
-    # This isn't very precise, but it shows, that the arc is broadly near (50km) reykjavik:
-    assert_in_delta(50_000, distance, 50_000)
+    seattle_bern_arc = @factory.line_string([seattle, bern])
+    distance = reykjavik.distance(seattle_bern_arc)
+    # This isn't very precise, but it shows, that the arc is broadly near (5km) reykjavik:
+    assert_in_delta(5_000, distance, 5_000)
   end
 
   def test_floating_point_perturbation


### PR DESCRIPTION
This PR implements two new methods to the `SphericalLineStringMethods` module, both can only take a `SphericalPointImpl` as a parameter:

`#distance`
`#closest_point`

The implementation requires the closest_point method to also be present in the internal `RGeo::Geographic::SphericalMath::ArcXYZ` class. This in turn depends on the ability to project a point on the unit sphere onto the great arc of a different arc. This is implemented in the `project_point` method, it introduces the building block which the other methods depend on. The other methods are more or less trivial.