### PR TITLE
Require ruby 3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   NewCops: enable
 
 Layout/ParameterAlignment:

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+**Breaking Changes**
+
+* Require ruby 3.1.4+ (@teeparham) #374
+
 **Minor Changes**
 
 * Add `simplify_polygon_hull` method to the CAPI factory (@oleksii-leonov) [#366](https://github.com/rgeo/rgeo/pull/366)

--- a/lib/rgeo/cartesian/factory.rb
+++ b/lib/rgeo/cartesian/factory.rb
@@ -121,7 +121,7 @@ module RGeo
           wkt_parser: symbolize_hash(data["wktp"]),
           wkb_parser: symbolize_hash(data["wkbp"]),
           buffer_resolution: data["bufr"],
-          coord_sys: coord_sys
+          coord_sys:
         )
       end
 
@@ -152,7 +152,7 @@ module RGeo
           wkt_parser: symbolize_hash(coder["wkt_parser"]),
           wkb_parser: symbolize_hash(coder["wkb_parser"]),
           buffer_resolution: coder["buffer_resolution"],
-          coord_sys: coord_sys
+          coord_sys:
         )
       end
 

--- a/lib/rgeo/coord_sys/cs/entities.rb
+++ b/lib/rgeo/coord_sys/cs/entities.rb
@@ -821,8 +821,8 @@ module RGeo
         private
 
         def wkt_content(standard_brackets)
-          array = [@ellipsoid.to_wkt(standard_brackets: standard_brackets)]
-          array << @wgs84_parameters.to_wkt(standard_brackets: standard_brackets) if @wgs84_parameters
+          array = [@ellipsoid.to_wkt(standard_brackets:)]
+          array << @wgs84_parameters.to_wkt(standard_brackets:) if @wgs84_parameters
           array
         end
       end
@@ -855,8 +855,8 @@ module RGeo
 
         # Iterates over the parameters of the projection.
 
-        def each_parameter(&block)
-          @parameters.each(&block)
+        def each_parameter(&)
+          @parameters.each(&)
         end
 
         def wkt_typename
@@ -1028,7 +1028,7 @@ module RGeo
         private
 
         def wkt_content(standard_brackets)
-          [@head.to_wkt(standard_brackets: standard_brackets), @tail.to_wkt(standard_brackets: standard_brackets)]
+          [@head.to_wkt(standard_brackets:), @tail.to_wkt(standard_brackets:)]
         end
       end
 
@@ -1092,9 +1092,9 @@ module RGeo
 
         def wkt_content(standard_brackets)
           [
-            @local_datum.to_wkt(standard_brackets: standard_brackets),
-            @unit.to_wkt(standard_brackets: standard_brackets)
-          ] + @axes.map { |ax| ax.to_wkt(standard_brackets: standard_brackets) }
+            @local_datum.to_wkt(standard_brackets:),
+            @unit.to_wkt(standard_brackets:)
+          ] + @axes.map { |ax| ax.to_wkt(standard_brackets:) }
         end
       end
 
@@ -1165,13 +1165,13 @@ module RGeo
 
         def wkt_content(standard_brackets)
           arr = [
-            @horizontal_datum.to_wkt(standard_brackets: standard_brackets),
-            @prime_meridian.to_wkt(standard_brackets: standard_brackets),
-            @linear_unit.to_wkt(standard_brackets: standard_brackets)
+            @horizontal_datum.to_wkt(standard_brackets:),
+            @prime_meridian.to_wkt(standard_brackets:),
+            @linear_unit.to_wkt(standard_brackets:)
           ]
-          arr << @axis0.to_wkt(standard_brackets: standard_brackets) if @axis0
-          arr << @axis1.to_wkt(standard_brackets: standard_brackets) if @axis1
-          arr << @axis2.to_wkt(standard_brackets: standard_brackets) if @axis2
+          arr << @axis0.to_wkt(standard_brackets:) if @axis0
+          arr << @axis1.to_wkt(standard_brackets:) if @axis1
+          arr << @axis2.to_wkt(standard_brackets:) if @axis2
           arr
         end
       end
@@ -1226,10 +1226,10 @@ module RGeo
 
         def wkt_content(standard_brackets)
           arr = [
-            @vertical_datum.to_wkt(standard_brackets: standard_brackets),
-            @vertical_unit.to_wkt(standard_brackets: standard_brackets)
+            @vertical_datum.to_wkt(standard_brackets:),
+            @vertical_unit.to_wkt(standard_brackets:)
           ]
-          arr << @axis.to_wkt(standard_brackets: standard_brackets) if @axis
+          arr << @axis.to_wkt(standard_brackets:) if @axis
           arr
         end
       end
@@ -1328,12 +1328,12 @@ module RGeo
 
         def wkt_content(standard_brackets)
           arr = [
-            @horizontal_datum.to_wkt(standard_brackets: standard_brackets),
-            @prime_meridian.to_wkt(standard_brackets: standard_brackets),
-            @angular_unit.to_wkt(standard_brackets: standard_brackets)
+            @horizontal_datum.to_wkt(standard_brackets:),
+            @prime_meridian.to_wkt(standard_brackets:),
+            @angular_unit.to_wkt(standard_brackets:)
           ]
-          arr << @axis0.to_wkt(standard_brackets: standard_brackets) if @axis0
-          arr << @axis1.to_wkt(standard_brackets: standard_brackets) if @axis1
+          arr << @axis0.to_wkt(standard_brackets:) if @axis0
+          arr << @axis1.to_wkt(standard_brackets:) if @axis1
           arr
         end
       end
@@ -1397,13 +1397,13 @@ module RGeo
 
         def wkt_content(standard_brackets)
           arr = [
-            @geographic_coordinate_system.to_wkt(standard_brackets: standard_brackets),
-            @projection.to_wkt(standard_brackets: standard_brackets)
+            @geographic_coordinate_system.to_wkt(standard_brackets:),
+            @projection.to_wkt(standard_brackets:)
           ]
-          @projection.each_parameter { |param| arr << param.to_wkt(standard_brackets: standard_brackets) }
-          arr << @linear_unit.to_wkt(standard_brackets: standard_brackets)
-          arr << @axis0.to_wkt(standard_brackets: standard_brackets) if @axis0
-          arr << @axis1.to_wkt(standard_brackets: standard_brackets) if @axis1
+          @projection.each_parameter { |param| arr << param.to_wkt(standard_brackets:) }
+          arr << @linear_unit.to_wkt(standard_brackets:)
+          arr << @axis0.to_wkt(standard_brackets:) if @axis0
+          arr << @axis1.to_wkt(standard_brackets:) if @axis1
           arr
         end
       end
@@ -1550,8 +1550,8 @@ module RGeo
         private
 
         def wkt_content(standard_brackets)
-          source_cs_wkt = "SOURCECS[#{source_cs.to_wkt(standard_brackets: standard_brackets)}]"
-          target_cs_wkt = "TARGETCS[#{target_cs.to_wkt(standard_brackets: standard_brackets)}]"
+          source_cs_wkt = "SOURCECS[#{source_cs.to_wkt(standard_brackets:)}]"
+          target_cs_wkt = "TARGETCS[#{target_cs.to_wkt(standard_brackets:)}]"
 
           [source_cs_wkt, target_cs_wkt]
         end

--- a/lib/rgeo/feature/geometry_collection.rb
+++ b/lib/rgeo/feature/geometry_collection.rb
@@ -94,7 +94,7 @@ module RGeo
       # Note that all GeometryCollection implementations must also
       # include the Enumerable mixin.
 
-      def each(&_block)
+      def each(&)
         raise Error::UnsupportedOperation, "Method #{self.class}#each not defined."
       end
 

--- a/lib/rgeo/feature/types.rb
+++ b/lib/rgeo/feature/types.rb
@@ -78,8 +78,8 @@ module RGeo
 
       # Iterates over the known immediate subtypes of this type.
 
-      def each_immediate_subtype(&block)
-        @subtypes&.each(&block)
+      def each_immediate_subtype(&)
+        @subtypes&.each(&)
       end
 
       # Returns the OpenGIS type name of this type. For example:

--- a/lib/rgeo/geographic/factory.rb
+++ b/lib/rgeo/geographic/factory.rb
@@ -139,7 +139,7 @@ module RGeo
           wkt_parser: symbolize_hash(data_["wktp"]),
           wkb_parser: symbolize_hash(data_["wkbp"]),
           buffer_resolution: data_["bufr"],
-          coord_sys: coord_sys
+          coord_sys:
         )
         proj_klass = data_["prjc"]
         proj_factory = data_["prjf"]
@@ -189,7 +189,7 @@ module RGeo
           wkt_parser: symbolize_hash(coder["wkt_parser"]),
           wkb_parser: symbolize_hash(coder["wkb_parser"]),
           buffer_resolution: coder["buffer_resolution"],
-          coord_sys: coord_sys
+          coord_sys:
         )
         proj_klass = coder["projectorclass"]
         proj_factory = coder["projection_factory"]

--- a/lib/rgeo/geographic/interface.rb
+++ b/lib/rgeo/geographic/interface.rb
@@ -323,7 +323,7 @@ module RGeo
           # Now we should have all the coordinate system info.
           factory = Geographic::Factory.new(
             "Projected",
-            coord_sys: coord_sys,
+            coord_sys:,
             srid: srid.to_i,
             has_z_coordinate: projection_factory.property(:has_z_coordinate),
             has_m_coordinate: projection_factory.property(:has_m_coordinate),
@@ -355,7 +355,7 @@ module RGeo
           # Now we should have all the coordinate system info.
           factory = Geographic::Factory.new(
             "Projected",
-            coord_sys: coord_sys,
+            coord_sys:,
             srid: srid.to_i,
             has_z_coordinate: opts[:has_z_coordinate],
             has_m_coordinate: opts[:has_m_coordinate],

--- a/lib/rgeo/geos/ffi_factory.rb
+++ b/lib/rgeo/geos/ffi_factory.rb
@@ -152,7 +152,7 @@ module RGeo
           wkt_parser: data["wktp"] && symbolize_hash(data["wktp"]),
           wkb_parser: data["wkbp"] && symbolize_hash(data["wkbp"]),
           auto_prepare: (data["apre"] ? :simple : :disabled),
-          coord_sys: coord_sys
+          coord_sys:
         )
       end
 
@@ -185,7 +185,7 @@ module RGeo
           wkt_parser: coder["wkt_parser"] && symbolize_hash(coder["wkt_parser"]),
           wkb_parser: coder["wkb_parser"] && symbolize_hash(coder["wkb_parser"]),
           auto_prepare: coder["auto_prepare"] == "disabled" ? :disabled : :simple,
-          coord_sys: coord_sys
+          coord_sys:
         )
       end
 

--- a/lib/rgeo/geos/zm_factory.rb
+++ b/lib/rgeo/geos/zm_factory.rb
@@ -47,7 +47,7 @@ module RGeo
           buffer_resolution: opts[:buffer_resolution], auto_prepare: opts[:auto_prepare],
           wkt_generator: opts[:wkt_generator], wkt_parser: opts[:wkt_parser],
           wkb_generator: opts[:wkb_generator], wkb_parser: opts[:wkb_parser],
-          srid: srid.to_i, coord_sys: coord_sys
+          srid: srid.to_i, coord_sys:
         }
         native_interface = opts[:native_interface] || Geos.preferred_native_interface
         if native_interface == :ffi
@@ -125,7 +125,7 @@ module RGeo
           wkt_parser: symbolize_hash(data["wktp"]),
           wkb_parser: symbolize_hash(data["wkbp"]),
           auto_prepare: (data["apre"] ? :simple : :disabled),
-          coord_sys: coord_sys
+          coord_sys:
         )
       end
 
@@ -161,7 +161,7 @@ module RGeo
           wkt_parser: symbolize_hash(coder["wkt_parser"]),
           wkb_parser: symbolize_hash(coder["wkb_parser"]),
           auto_prepare: coder["auto_prepare"] == "disabled" ? :disabled : :simple,
-          coord_sys: coord_sys
+          coord_sys:
         )
       end
 

--- a/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
+++ b/lib/rgeo/impl_helper/basic_geometry_collection_methods.rb
@@ -35,8 +35,8 @@ module RGeo
         @elements[idx]
       end
 
-      def each(&block)
-        @elements.each(&block)
+      def each(&)
+        @elements.each(&)
       end
 
       def geometries

--- a/lib/rgeo/impl_helper/utils.rb
+++ b/lib/rgeo/impl_helper/utils.rb
@@ -27,7 +27,7 @@ module RGeo
         # Create a coord sys based on the SRID if one was not given
         coord_sys = coord_sys_class.create(srid) if coord_sys.nil? && srid != 0
 
-        { coord_sys: coord_sys, srid: srid }
+        { coord_sys:, srid: }
       end
 
       private

--- a/rgeo.gemspec
+++ b/rgeo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Daniel Azuma", "Tee Parham"]
   spec.email = ["dazuma@gmail.com", "parhameter@gmail.com", "kfdoggett@gmail.com", "buonomo.ulysse@gmail.com"]
   spec.homepage = "https://github.com/rgeo/rgeo"
-  spec.required_ruby_version = ">= 2.7.7"
+  spec.required_ruby_version = ">= 3.1.4"
   spec.license = "BSD-3-Clause"
 
   spec.metadata["funding_uri"] = "https://opencollective.com/rgeo"


### PR DESCRIPTION
### Summary

* Require ruby 3.1.4+. Ruby 3.0 is EOL: https://www.ruby-lang.org/en/downloads/branches/
* Update the target rubocop version to 3.1 and run auto-correct.

I chose 3.1.4 as the minimum version since the earlier patch releases for 3.1 have CVEs & 3.1.4+ have been released for a while.

Note: CI already tests only 3.1+.
