### PR TITLE
fix: Ruby 4.0 compatibility

### DIFF
--- a/ext/geos_c_impl/factory.h
+++ b/ext/geos_c_impl/factory.h
@@ -105,8 +105,8 @@ extern const rb_data_type_t rgeo_geometry_type;
   (_RGEO_TYPEDDATA_P(object, &rgeo_geometry_type))
 
 #define _RGEO_TYPEDDATA_P(object, data_type)                                   \
-  (TYPE(object) == T_DATA && RTYPEDDATA(object)->typed_flag == 1 &&            \
-   RTYPEDDATA(object)->type == data_type)
+  (RB_TYPE_P(object, T_DATA) && RTYPEDDATA_P(object) &&                        \
+   RTYPEDDATA_TYPE(object) == data_type)
 
 // Returns the RGeo_FactoryData* given a ruby Factory object
 #define RGEO_FACTORY_DATA_PTR(factory)                                         \

--- a/rgeo.gemspec
+++ b/rgeo.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "ffi-geos", "~> 2.2"
   spec.add_development_dependency "minitest", "~> 5.11"
+  spec.add_development_dependency "ostruct"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-compiler", "~> 1.0"
   spec.add_development_dependency "rubocop", "~> 1.36.0"


### PR DESCRIPTION
Replace deprecated typed_flag check with RTYPEDDATA_P/RTYPEDDATA_TYPE macros

was deprecated since ruby 3.