### PR TITLE
fix: mark error_handler as NORETURN to silence compiler warning

### DIFF
--- a/ext/geos_c_impl/globals.c
+++ b/ext/geos_c_impl/globals.c
@@ -56,8 +56,7 @@ notice_handler(const char* fmt, ...)
 #endif
 }
 
-static void
-error_handler(const char* fmt, ...)
+NORETURN(static void error_handler(const char* fmt, ...))
 {
   // See https://en.cppreference.com/w/c/io/vfprintf
   va_list args1;


### PR DESCRIPTION
The error_handler function always calls rb_raise which never returns. 
Adding NORETURN attribute eliminates the -Wmissing-noreturn warning when compiling with Ruby 4.1-dev.
