### PR TITLE
Precision option for simple_factory

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ### Unreleased
 
+**Bug Fixes**
+
+* Add a `:precision` option for `simple_factory` instances to reduce invalid self-intersection issues
+* Add a new tests to validate `simple_factory` polygons with non-integer vertices
+
 ### 3.1.0 / 2025-01-20
 
 **Minor Changes**

--- a/lib/rgeo/cartesian/factory.rb
+++ b/lib/rgeo/cartesian/factory.rb
@@ -38,6 +38,8 @@ module RGeo
         @coord_sys = coord_sys_info[:coord_sys]
         @srid = coord_sys_info[:srid]
 
+        @precision = opts[:precision] || 5
+
         @buffer_resolution = opts[:buffer_resolution].to_i
         @buffer_resolution = 1 if @buffer_resolution < 1
 
@@ -186,7 +188,7 @@ module RGeo
       # See RGeo::Feature::Factory#point
 
       def point(x, y, *extra)
-        PointImpl.new(self, x, y, *extra)
+        PointImpl.new(self, x.round(@precision), y.round(@precision), *extra)
       end
 
       # See RGeo::Feature::Factory#line_string

--- a/lib/rgeo/cartesian/interface.rb
+++ b/lib/rgeo/cartesian/interface.rb
@@ -70,6 +70,11 @@ module RGeo
       # [<tt>:coord_sys_class</tt>]
       #   CoordSys::CS::CoordinateSystem implementation used to instansiate
       #   a coord_sys based on the :srid given.
+      # [<tt>:precision</tt>]
+      #   Set the rounding precision for new points created by this factory. This
+      #   will help eliminate precision-related issues that occasionally cause
+      #   falsely-reported segment intersections.
+      #   Default is 5.
       # [<tt>:has_z_coordinate</tt>]
       #   Support a Z coordinate. Default is false.
       # [<tt>:has_m_coordinate</tt>]

--- a/test/common/validity_tests.rb
+++ b/test/common/validity_tests.rb
@@ -81,6 +81,7 @@ module RGeo
 
         def test_validity_invalid_reason
           assert_nil(square_polygon.invalid_reason)
+          assert_nil(square_polygon_decimals.invalid_reason)
           assert_equal("Self-intersection", bowtie_polygon.invalid_reason)
         end
 
@@ -115,6 +116,20 @@ module RGeo
                 @factory.point(1, 1),
                 @factory.point(0, 1),
                 @factory.point(0, 0)
+              ]
+            )
+          )
+        end
+
+        def square_polygon_decimals
+          @square_polygon_decimals ||= @factory.polygon(
+            @factory.linear_ring(
+              [
+                @factory.point(-180.0, 90.0),
+                @factory.point(180.0, 90.0),
+                @factory.point(180.0, -85.044),
+                @factory.point(-180.0, -85.044),
+                @factory.point(-180.0, 90.0)
               ]
             )
           )


### PR DESCRIPTION
### Summary

Adding a precision option to simple_factory to reduce incorrect self-intersection errors.

Addresses the issue I reported in https://github.com/rgeo/rgeo/issues/393

### Other Information

I was only able to reliably reproduce the bug with `simple_factory`, so I only added the precision option to that factory.  It could be added to other factories if needed.  I decided to go with a precision of 5 decimal places as this is still very accurate for most needs (and could be expanded if finer precision is needed).